### PR TITLE
feats: Custom API & hotkey shortcut selection. fixes: Responsiveness and early characters cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Wisper is a WisprFlow-like voice dictation application for Linux. It provides se
 
 ## Features
 
-- **Global Hotkey** - Press `Shift+Space` to start/stop recording from anywhere
+- **Global Hotkey** - Press hotkey to start/stop recording from anywhere
 - **Direct Text Input** - Transcribed text is typed directly at your cursor (no copy-paste needed)
 - **AI Transcription** - Transcribe audio using OpenAI Whisper via Groq or OpenAI APIs
 - **Multilingual** - Supports 99+ languages with automatic detection
@@ -12,14 +12,14 @@ Wisper is a WisprFlow-like voice dictation application for Linux. It provides se
 - **System Tray** - Quick access to settings and app controls
 - **Compact Settings** - Configure API keys in a dedicated window
 - **Wayland & X11 Support** - Works on both display servers
-- **Privacy First** - Records locally before sending to API
+- **Privacy First** - Records locally before sending to API. The API endpoint can be local too (e.g. see [`speaches`](https://speaches.ai))
 
 ## Requirements
 
 - Linux (Debian/Ubuntu 22.04+)
 - Microphone access
 - Internet connection (for API calls)
-- **ydotool** - Required for direct text input (install via your package manager)
+- **ydotool** - Used for direct text input (install instructions below)
 - **Wayland users**: Need to set up custom keyboard shortcut (see Wayland Setup below)
 
 ## Installation
@@ -44,6 +44,10 @@ pnpm run package
 
 ### Install ydotool
 
+[`ydotool`](https://github.com/ReimuNotMoe/ydotool) is responsible for sending the speech output into the active input field.
+
+Pre-packaged versions are available but may be older versions:
+
 ```bash
 # Ubuntu/Debian
 sudo apt install ydotool
@@ -53,6 +57,17 @@ sudo dnf install ydotool
 
 # Arch Linux
 sudo pacman -S ydotool
+```
+
+In case of trouble (see #Troubleshooting), you may want to use the [latest release](https://github.com/ReimuNotMoe/ydotool/releases/latest):
+
+**Installing and running `ydotoold` as a service** is also recommended. This improves responsiveness and reliability. If your package manager doesn't provide a service config (as ubuntu's doesn't), you can get the `systemd` config [here](https://github.com/ReimuNotMoe/ydotool/raw/refs/heads/master/Daemon/systemd/ydotoold.service.in). Save it as `$HOME/.config/systemd/user/ydotoold.service`, and edit so that `ExecStart` points to `which ydotoold`. Then do this once:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user start ydotoold   # runs service as the current user
+systemctl --user status ydotoold  # check that it's successfully running
+systemctl --user enable ydotoold  # to run it automatically at boot
 ```
 
 ### From Release
@@ -67,19 +82,21 @@ Download the latest `.AppImage` or `.deb` package from the [Releases](https://gi
 2. Choose your API provider:
    - **Groq**: Free, fast Whisper models (recommended)
    - **OpenAI**: Official Whisper API
-3. Enter your API key
-4. Click **Save**
+   - **Custom**: Any OpenAI transcription-API-compatible model endpoint (e.g. locally-served)
+3. Enter your API key (optional for custom)
+4. Choose Wisper's *hotkey* (`Shift-Space` by default)
+5. Click **Save**
 
 ### Recording
 
-1. Press `Shift+Space` to start recording (bar appears)
-2. Speak into your microphone
-3. Press `Shift+Space` again to stop
-4. Text is transcribed and typed directly at your cursor
+1. Press your *hotkey* to start recording (bar appears)
+2. When the chime sounds and the bar turns red, **Speak into your microphone**
+3. Press your *hotkey* again to stop
+4. Text is transcribed and typed directly at your cursor location
 
 ### System Tray
 
-- **Left-click**: Toggle recording
+- **Left-click**: Toggle recording (same has hotkey-press)
 - **Right-click**: Open menu (Settings, Quit)
 
 ## Wayland Setup (GNOME/Debian)
@@ -113,12 +130,13 @@ For development:
 
 ### API Keys
 
-Wisper supports two transcription providers:
+Wisper supports these transcription providers:
 
 | Provider | Model | Cost | Get API Key |
 |----------|-------|------|-------------|
 | **Groq** (Recommended) | `whisper-large-v3-turbo` | Free | [console.groq.com](https://console.groq.com/) |
 | **OpenAI** | `whisper-1` | Paid | [platform.openai.com](https://platform.openai.com/api-keys) |
+| **Custom** | Any OpenAI API'd ASR model | Free if local |  |
 
 ### Settings
 
@@ -126,8 +144,9 @@ Access settings via system tray → **Settings**
 
 | Option | Description |
 |--------|-------------|
-| Provider | Choose between Groq and OpenAI |
+| Provider | Choose between Groq, OpenAI and Custom |
 | API Key | Your provider's API key |
+| Shortcut | *Shift-Space*, *Ctrl-Alt-Space*, *Ctrl-Shift-Space*, *Ctrl-Shift-Insert*, or *Alt-F12* |
 
 ## Building
 
@@ -144,8 +163,9 @@ pnpm run package          # Create distributables (.AppImage, .deb)
 ## Troubleshooting
 
 ### ydotool not working
+- You will see an error in `/tmp/wisper.log`, or test manually with `ydotool type "some text"`. "some text" should appear in the terminal.
 - Ensure ydotool is installed
-- Check permissions: `sudo chmod 666 /dev/uinput`
+- The user running `wisper` needs write access to `/dev/uinput`. Either: `sudo chmod 666 /dev/uinput`, or follow [this procedure](https://github.com/ReimuNotMoe/ydotool/issues/36#issuecomment-788148567)
 - For Wayland, ydotool may require additional setup
 
 ### Global shortcut not working on Wayland

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -239,16 +239,31 @@ if (!gotTheLock) {
     globalShortcut.unregisterAll();
 
     if (!isWayland) {
-      globalShortcut.register("Ctrl+Alt+Space", () => {
+      globalShortcut.register("Shift+Space", () => {
         toggleRecording();
       });
     } else if (mainWindow) {
-      localShortcut.register(mainWindow, "Ctrl+Alt+Space", () => {
+      localShortcut.register(mainWindow, "Shift+Space", () => {
         toggleRecording();
       });
     }
   });
 }
+
+ipcMain.handle("save-debug-audio", async (event, arrayBuffer, mimeType) => {
+  try {
+    const extension = mimeType.includes("ogg") ? "ogg" : "webm";
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const debugDir = "/tmp/wisper-debug";
+    fs.mkdirSync(debugDir, { recursive: true });
+    const filePath = path.join(debugDir, `recording-${timestamp}.${extension}`);
+    fs.writeFileSync(filePath, Buffer.from(arrayBuffer));
+    return filePath;
+  } catch (err) {
+    console.error("Failed to save debug audio:", err);
+    return null;
+  }
+});
 
 app.on("window-all-closed", () => {
   // Keep app running in tray

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -33,7 +33,8 @@ try {
 function toggleRecording() {
   if (mainWindow) {
     if (!isRecording) {
-      mainWindow.show();
+      mainWindow.setIgnoreMouseEvents(false);
+      mainWindow.setAlwaysOnTop(true);
       mainWindow.webContents.send("start-recording");
       isRecording = true;
     } else {
@@ -66,7 +67,7 @@ function createWindow() {
     resizable: true,
     movable: true,
     skipTaskbar: true,
-    show: false,
+    type: "notification",   // Linux: _NET_WM_WINDOW_TYPE_NOTIFICATION — excludes from Alt-Tab, atom is pre-cached by Chromium
     webPreferences: {
       preload: path.join(__dirname, "preload.cjs"),
       contextIsolation: true,
@@ -84,6 +85,17 @@ function createWindow() {
 
   mainWindow.on("closed", () => {
     mainWindow = null;
+  });
+
+  // Window is shown once at startup (transparent + click-through).
+  // All subsequent visibility changes are handled via setIgnoreMouseEvents
+  // to avoid OS window-manager sounds on every recording toggle.
+  // Window is shown once at startup (transparent + click-through + not on top).
+  // All subsequent visibility changes use setIgnoreMouseEvents / setAlwaysOnTop
+  // to avoid OS window-manager sounds on every recording toggle.
+  mainWindow.once("ready-to-show", () => {
+    mainWindow.setIgnoreMouseEvents(true);
+    mainWindow.setAlwaysOnTop(false);
   });
 }
 
@@ -166,7 +178,8 @@ function createTray() {
 // IPC Handlers
 ipcMain.handle("hide-window", async () => {
   if (mainWindow) {
-    mainWindow.hide();
+    mainWindow.setIgnoreMouseEvents(true);
+    mainWindow.setAlwaysOnTop(false);
     isRecording = false;
   }
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -88,8 +88,8 @@ function createWindow() {
   const { screen } = require("electron");
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width, height } = primaryDisplay.workAreaSize;
-  const winWidth = 320;
-  const winHeight = 80;
+  const winWidth = 340;
+  const winHeight = 90;
   const x = Math.round((width - winWidth) / 2);
   const y = Math.round(height - winHeight - 20);
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -34,21 +34,6 @@ function toggleRecording() {
   if (mainWindow) {
     if (!isRecording) {
       mainWindow.show();
-      positionWindowAtBottom();
-      mainWindow.webContents.send("start-recording");
-      isRecording = true;
-    } else {
-      mainWindow.webContents.send("stop-recording");
-      isRecording = false;
-    }
-  }
-}
-
-// Toggle recording: show+record or stop+hide
-function toggleRecording() {
-  if (mainWindow) {
-    if (!isRecording) {
-      mainWindow.show();
       mainWindow.webContents.send("start-recording");
       isRecording = true;
     } else {
@@ -192,10 +177,12 @@ ipcMain.handle("copy-to-clipboard", async (event, text) => {
 
 ipcMain.handle("paste-to-cursor", async (event, text) => {
   const { execSync } = require("child_process");
-  
+
   try {
     const tempFile = '/tmp/wisper-text.txt';
     require('fs').writeFileSync(tempFile, text);
+    // Wait for the window to hide and the OS to return focus to the target app
+    await new Promise(resolve => setTimeout(resolve, 250));
     const timeout = Math.max(5000, text.length * 50);
     execSync(`ydotool type --file ${tempFile}`, { timeout, stdio: 'ignore' });
   } catch (err) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -182,6 +182,7 @@ function createTray() {
 ipcMain.handle("hide-window", async () => {
   if (mainWindow) {
     mainWindow.hide();
+    isRecording = false;
   }
 });
 
@@ -192,12 +193,13 @@ ipcMain.handle("copy-to-clipboard", async (event, text) => {
 
 ipcMain.handle("paste-to-cursor", async (event, text) => {
   const { execSync } = require("child_process");
-  
+
   try {
     const tempFile = '/tmp/wisper-text.txt';
     require('fs').writeFileSync(tempFile, text);
     const timeout = Math.max(5000, text.length * 50);
-    execSync(`ydotool type --file ${tempFile}`, { timeout, stdio: 'ignore' });
+    // key delay (how fast the text is written) may be something worth exposing to the user
+    execSync(`ydotool type --delay 100 --key-delay 15 --file ${tempFile}`, { timeout, stdio: 'ignore' });
   } catch (err) {
     require('fs').appendFileSync('/tmp/wisper.log', `error: ${err.message}\n`);
   }
@@ -240,9 +242,7 @@ if (!gotTheLock) {
       globalShortcut.register("Shift+Space", () => {
         toggleRecording();
       });
-    }
-
-    if (mainWindow) {
+    } else if (mainWindow) {
       localShortcut.register(mainWindow, "Shift+Space", () => {
         toggleRecording();
       });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -107,6 +107,7 @@ function createWindow() {
     resizable: true,
     movable: true,
     skipTaskbar: true,
+    focusable: false,
     type: "notification",   // Linux: _NET_WM_WINDOW_TYPE_NOTIFICATION — excludes from Alt-Tab, atom is pre-cached by Chromium
     webPreferences: {
       preload: path.join(__dirname, "preload.cjs"),
@@ -148,7 +149,8 @@ function createSettingsWindow() {
 
   settingsWindow = new BrowserWindow({
     minWidth: 320,
-    minHeight: 385,
+    minHeight: 360,
+    height: 630,
     frame: true,
     resizable: true,
     minimizable: true,
@@ -283,6 +285,10 @@ app.on("window-all-closed", () => {
 
 app.on("will-quit", () => {
   globalShortcut.unregisterAll();
+});
+
+process.on("SIGINT", () => {
+  app.quit();
 });
 
 app.on("before-quit", () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -18,6 +18,7 @@ let mainWindow = null;
 let settingsWindow = null;
 let tray = null;
 let isRecording = false;
+let currentShortcut = "Shift+Space";
 
 const isDev = !app.isPackaged;
 
@@ -28,6 +29,22 @@ let isWayland = false;
 try {
   isWayland = process.env.XDG_SESSION_TYPE === "wayland";
 } catch (e) {}
+
+function registerShortcut(shortcut) {
+  if (!isWayland) {
+    globalShortcut.unregisterAll();
+    globalShortcut.register(shortcut, () => {
+      toggleRecording();
+    });
+  }
+  if (mainWindow) {
+    localShortcut.unregisterAll(mainWindow);
+    localShortcut.register(mainWindow, shortcut, () => {
+      toggleRecording();
+    });
+  }
+  currentShortcut = shortcut;
+}
 
 // Toggle recording: show+record or stop+hide
 function toggleRecording() {
@@ -212,6 +229,11 @@ ipcMain.on("set-recording-state", (event, state) => {
   isRecording = state;
 });
 
+ipcMain.handle("update-shortcut", async (event, shortcut) => {
+  registerShortcut(shortcut);
+  return true;
+});
+
 const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
@@ -234,19 +256,7 @@ if (!gotTheLock) {
       }
     });
 
-    globalShortcut.unregisterAll();
-
-    if (!isWayland) {
-      globalShortcut.register("Shift+Space", () => {
-        toggleRecording();
-      });
-    }
-
-    if (mainWindow) {
-      localShortcut.register(mainWindow, "Shift+Space", () => {
-        toggleRecording();
-      });
-    }
+    registerShortcut("Shift+Space");
   });
 }
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -30,12 +30,14 @@ try {
   isWayland = process.env.XDG_SESSION_TYPE === "wayland";
 } catch (e) {}
 
-function registerShortcut(shortcut) {
+async function registerShortcut(shortcut) {
   if (!isWayland) {
     globalShortcut.unregisterAll();
-    globalShortcut.register(shortcut, () => {
-      toggleRecording();
-    });
+    try {
+      await globalShortcut.register(shortcut, () => {
+        toggleRecording();
+      });
+    } catch {}
   } else if (mainWindow) {
     localShortcut.unregisterAll(mainWindow);
     localShortcut.register(mainWindow, shortcut, () => {
@@ -43,6 +45,28 @@ function registerShortcut(shortcut) {
     });
   }
   currentShortcut = shortcut;
+  updateTrayMenu();
+}
+
+function updateTrayMenu() {
+  if (!tray) return;
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: `Toggle Recording (${currentShortcut})`,
+      click: () => { toggleRecording(); },
+    },
+    { type: "separator" },
+    {
+      label: "Settings",
+      click: () => { createSettingsWindow(); },
+    },
+    { type: "separator" },
+    {
+      label: "Quit",
+      click: () => { app.quit(); },
+    },
+  ]);
+  tray.setContextMenu(contextMenu);
 }
 
 // Toggle recording: show+record or stop+hide
@@ -89,6 +113,7 @@ function createWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      webSecurity: false, // disable cors checks, same-origin policy, mixed content blocking, file:// isolation, so we can load from APIs that don't send cors headers
     },
     icon: path.join(__dirname, "../assets/icon.png"),
   });
@@ -123,7 +148,7 @@ function createSettingsWindow() {
 
   settingsWindow = new BrowserWindow({
     minWidth: 320,
-    minHeight: 360,
+    minHeight: 385,
     frame: true,
     resizable: true,
     minimizable: true,
@@ -160,31 +185,8 @@ function createTray() {
   const trayIcon = icon.resize({ width: 22, height: 22 });
   tray = new Tray(trayIcon);
 
-  const contextMenu = Menu.buildFromTemplate([
-    {
-      label: "Toggle Recording (Shift+Space)",
-      click: () => {
-        toggleRecording();
-      },
-    },
-    { type: "separator" },
-    {
-      label: "Settings",
-      click: () => {
-        createSettingsWindow();
-      },
-    },
-    { type: "separator" },
-    {
-      label: "Quit",
-      click: () => {
-        app.quit();
-      },
-    },
-  ]);
-
   tray.setToolTip("Wisper - Voice Dictation");
-  tray.setContextMenu(contextMenu);
+  updateTrayMenu();
 
   tray.on("click", () => {
     toggleRecording();
@@ -231,7 +233,7 @@ ipcMain.on("set-recording-state", (event, state) => {
 });
 
 ipcMain.handle("update-shortcut", async (event, shortcut) => {
-  registerShortcut(shortcut);
+  await registerShortcut(shortcut);
   return true;
 });
 
@@ -256,8 +258,7 @@ if (!gotTheLock) {
         createWindow();
       }
     });
-
-    registerShortcut("Shift+Space");
+    // shortcut registration will occur (via IPC) immediately after the renderer loads
   });
 }
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -226,11 +226,11 @@ if (!gotTheLock) {
     globalShortcut.unregisterAll();
 
     if (!isWayland) {
-      globalShortcut.register("Shift+Space", () => {
+      globalShortcut.register("Ctrl+Alt+Space", () => {
         toggleRecording();
       });
     } else if (mainWindow) {
-      localShortcut.register(mainWindow, "Shift+Space", () => {
+      localShortcut.register(mainWindow, "Ctrl+Alt+Space", () => {
         toggleRecording();
       });
     }

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -21,4 +21,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Remove listeners
   removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
+
+  // Debug
+  saveDebugAudio: (arrayBuffer, mimeType) =>
+    ipcRenderer.invoke("save-debug-audio", arrayBuffer, mimeType),
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Settings
   onOpenSettings: (callback) => ipcRenderer.on("open-settings", callback),
+  updateShortcut: (shortcut) => ipcRenderer.invoke("update-shortcut", shortcut),
 
   // Remove listeners
   removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "electron": "electron . --no-sandbox",
-    "electron:dev": "concurrently \"pnpm run dev\" \"wait-on http://localhost:5173 && electron . --no-sandbox\"",
+    "electron:dev": "concurrently --kill-others --success first \"vite\" \"wait-on http://localhost:5173 && electron . --no-sandbox\"",
     "package": "pnpm run build && electron-builder --linux"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "electron": "electron . --no-sandbox",
-    "electron:dev": "concurrently --kill-others --success first \"vite\" \"wait-on http://localhost:5173 && electron . --no-sandbox\"",
+    "electron:dev": "trap 'exit 0' INT TERM; concurrently --kill-others --success first 'vite' 'wait-on http://localhost:5173 && electron . --no-sandbox'",
     "package": "pnpm run build && electron-builder --linux"
   },
   "keywords": [

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -157,8 +157,6 @@ function RecordingBar() {
   }, [handleStartRecording, handleStopRecording]);
 
   const renderContent = () => {
-    if (!overlayVisible) return null;
-
     if (error) {
       return (
         <div className="flex items-center gap-2">
@@ -170,7 +168,7 @@ function RecordingBar() {
 
     if (isTranscribing) {
       return (
-        <div className="flex items-center gap-1.5 h-6">
+        <div className="flex items-center gap-1.5 h-8">
           <span className="w-1.5 bg-primary-500 rounded-full animate-[bounce_0.6s_infinite]" style={{ height: '40%' }} />
           <span className="w-1.5 bg-primary-500 rounded-full animate-[bounce_0.6s_infinite_0.1s]" style={{ height: '80%' }} />
           <span className="w-1.5 bg-primary-500 rounded-full animate-[bounce_0.6s_infinite_0.2s]" style={{ height: '60%' }} />
@@ -188,8 +186,15 @@ function RecordingBar() {
   };
 
   return (
-    <div className="w-full h-full flex items-center justify-center px-4">
-      {renderContent()}
+    <div className="w-full h-full flex items-center justify-center">
+      {overlayVisible && (
+        <div
+          className="flex items-center justify-center px-6 h-20 min-w-[198px] rounded-full ring-1 ring-white/10 shadow-xl"
+          style={{ background: "rgba(14, 14, 22, 0.60)" }}
+        >
+          {renderContent()}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -116,6 +116,9 @@ function RecordingBar() {
         handleStopRecording();
       });
 
+      const savedShortcut = localStorage.getItem("wisper_shortcut") || "Shift+Space";
+      window.electronAPI.updateShortcut(savedShortcut);
+
       return () => {
         window.electronAPI.removeAllListeners("start-recording");
         window.electronAPI.removeAllListeners("stop-recording");
@@ -154,7 +157,7 @@ function RecordingBar() {
         <div className="w-6 h-6 rounded-full border-2 border-white/20 flex items-center justify-center">
           <div className="w-2 h-2 rounded-full bg-white/40" />
         </div>
-        <span className="text-xs font-medium">Press Shift+Space to record</span>
+        <span className="text-xs font-medium">Press {localStorage.getItem("wisper_shortcut") || "Shift+Space"} to record</span>
       </div>
     );
   };

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -9,14 +9,36 @@ function RecordingBar() {
   const { isRecording, audioLevel, startRecording, stopRecording } =
     useAudioRecorder();
 
-  const getApiKey = () => localStorage.getItem("wisper_api_key") || "";
-
   const transcribeAudio = async (audioBlob: Blob) => {
-    const apiKey = getApiKey();
     const provider = localStorage.getItem("wisper_provider") || "groq";
 
-    if (!apiKey) {
-      setError("No API key. Open Settings from tray.");
+    let apiKey: string;
+    let apiUrl: string;
+    let model: string;
+
+    if (provider === "groq") {
+      apiKey = localStorage.getItem("wisper_groq_key") || "";
+      apiUrl = "https://api.groq.com/openai/v1/audio/transcriptions";
+      model = "whisper-large-v3-turbo";
+    } else if (provider === "openai") {
+      apiKey = localStorage.getItem("wisper_openai_key") || "";
+      apiUrl = "https://api.openai.com/v1/audio/transcriptions";
+      model = "whisper-1";
+    } else {
+      apiKey = localStorage.getItem("wisper_custom_key") || "";
+      apiUrl = localStorage.getItem("wisper_custom_url") || "";
+      model = localStorage.getItem("wisper_custom_model") || "";
+    }
+
+    let errMsg = ""
+    if (provider === "custom" && !(apiUrl && model)) {
+      errMsg = "API URL or model is unset. Open Settings from tray.";
+    } else if (provider !== "custom" && !apiKey) {
+      // apiKey is not required for custom
+      errMsg = "No API key. Open Settings from tray.";
+    }
+    if (errMsg) {
+      setError(errMsg);
       setTimeout(() => {
         if (window.electronAPI) {
           window.electronAPI.hideWindow();
@@ -32,17 +54,6 @@ function RecordingBar() {
       const extension = audioBlob.type.includes("ogg") ? "ogg" : "webm";
       formData.append("file", audioBlob, `recording.${extension}`);
       formData.append("response_format", "text");
-
-      let apiUrl: string;
-      let model: string;
-
-      if (provider === "groq") {
-        apiUrl = "https://api.groq.com/openai/v1/audio/transcriptions";
-        model = "whisper-large-v3-turbo";
-      } else {
-        apiUrl = "https://api.openai.com/v1/audio/transcriptions";
-        model = "whisper-1";
-      }
 
       formData.append("model", model);
 

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -71,12 +71,10 @@ function RecordingBar() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        if (provider === "custom" && response.status == 405)
-          throw new Error("API error 405. Did you include the full v1/audio/transcriptions endpoint URL?")
-        else
-          throw new Error(
-            errorData.error?.message || `API error ${response.status}: ${response.statusText}`,
-          );
+        throw new Error(
+          errorData.error?.message ||
+          `API error ${response.status}: ${response.statusText}${provider === "custom" && response.status == 404 || response.status == 405 ? ", Did you include the 'v1/audio/transcriptions' endpoint URL?":""}`,
+        );
       }
 
       const text = await response.text();

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from "react";
 import { useAudioRecorder } from "../hooks/useAudioRecorder";
 import { Waveform } from "./Waveform";
 
+const DEBUG_AUDIO = false;
+
 function RecordingBar() {
   const [overlayVisible, setOverlayVisible] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
@@ -117,6 +119,11 @@ function RecordingBar() {
       window.electronAPI.setRecordingState(false);
     }
     if (audioBlob) {
+      if (DEBUG_AUDIO && window.electronAPI?.saveDebugAudio) {
+        const arrayBuffer = await audioBlob.arrayBuffer();
+        const savedPath = await window.electronAPI.saveDebugAudio(arrayBuffer, audioBlob.type);
+        if (savedPath) console.log("Debug audio saved to:", savedPath);
+      }
       await transcribeAudio(audioBlob);
     } else if (window.electronAPI) {
       setOverlayVisible(false);

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -3,6 +3,7 @@ import { useAudioRecorder } from "../hooks/useAudioRecorder";
 import { Waveform } from "./Waveform";
 
 function RecordingBar() {
+  const [overlayVisible, setOverlayVisible] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -41,6 +42,7 @@ function RecordingBar() {
       setError(errMsg);
       setTimeout(() => {
         if (window.electronAPI) {
+          setOverlayVisible(false);
           window.electronAPI.hideWindow();
         }
       }, 2000);
@@ -76,9 +78,11 @@ function RecordingBar() {
       const trimmedText = text.trim();
 
       if (trimmedText && window.electronAPI) {
+        setOverlayVisible(false);
         window.electronAPI.hideWindow();
         window.electronAPI.pasteToCursor(trimmedText);
       } else if (window.electronAPI) {
+        setOverlayVisible(false);
         window.electronAPI.hideWindow();
       }
     } catch (err) {
@@ -86,6 +90,7 @@ function RecordingBar() {
       setError(err instanceof Error ? err.message : "Transcription failed");
       setTimeout(() => {
         if (window.electronAPI) {
+          setOverlayVisible(false);
           window.electronAPI.hideWindow();
         }
       }, 2000);
@@ -114,6 +119,7 @@ function RecordingBar() {
     if (audioBlob) {
       await transcribeAudio(audioBlob);
     } else if (window.electronAPI) {
+      setOverlayVisible(false);
       window.electronAPI.hideWindow();
     }
   }, [stopRecording]);
@@ -122,6 +128,7 @@ function RecordingBar() {
   useEffect(() => {
     if (window.electronAPI) {
       window.electronAPI.onStartRecording(() => {
+        setOverlayVisible(true);
         handleStartRecording();
       });
 
@@ -137,6 +144,8 @@ function RecordingBar() {
   }, [handleStartRecording, handleStopRecording]);
 
   const renderContent = () => {
+    if (!overlayVisible) return null;
+
     if (error) {
       return (
         <div className="flex items-center gap-2">

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -71,9 +71,12 @@ function RecordingBar() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(
-          errorData.error?.message || `API error: ${response.status}`,
-        );
+        if (provider === "custom" && response.status == 405)
+          throw new Error("API error 405. Did you include the full v1/audio/transcriptions endpoint URL?")
+        else
+          throw new Error(
+            errorData.error?.message || `API error ${response.status}: ${response.statusText}`,
+          );
       }
 
       const text = await response.text();

--- a/src/components/RecordingBar.tsx
+++ b/src/components/RecordingBar.tsx
@@ -102,6 +102,8 @@ function RecordingBar() {
     }
     if (audioBlob) {
       await transcribeAudio(audioBlob);
+    } else if (window.electronAPI) {
+      window.electronAPI.hideWindow();
     }
   }, [stopRecording]);
 
@@ -149,14 +151,7 @@ function RecordingBar() {
       return <Waveform audioLevel={audioLevel} isRecording={isRecording} />;
     }
 
-    return (
-      <div className="flex items-center gap-2 text-white/40">
-        <div className="w-6 h-6 rounded-full border-2 border-white/20 flex items-center justify-center">
-          <div className="w-2 h-2 rounded-full bg-white/40" />
-        </div>
-        <span className="text-xs font-medium">Press Shift+Space to record</span>
-      </div>
-    );
+    return <Waveform audioLevel={0} isRecording={false} />;
   };
 
   return (

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect } from "react";
 
-type Provider = "groq" | "openai";
+type Provider = "groq" | "openai" | "custom";
 
 function Settings() {
   const [groqKey, setGroqKey] = useState("");
   const [openaiKey, setOpenaiKey] = useState("");
+  const [customKey, setCustomKey] = useState("");
+  const [customUrl, setCustomUrl] = useState("");
+  const [customModel, setCustomModel] = useState("");
   const [provider, setProvider] = useState<Provider>("groq");
   const [saved, setSaved] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -12,22 +15,24 @@ function Settings() {
   useEffect(() => {
     setGroqKey(localStorage.getItem("wisper_groq_key") || "");
     setOpenaiKey(localStorage.getItem("wisper_openai_key") || "");
+    setCustomKey(localStorage.getItem("wisper_custom_key") || "");
+    setCustomUrl(localStorage.getItem("wisper_custom_url") || "");
+    setCustomModel(localStorage.getItem("wisper_custom_model") || "");
     setProvider(
       (localStorage.getItem("wisper_provider") as Provider) || "groq",
     );
   }, []);
 
-  const currentKey = provider === "groq" ? groqKey : openaiKey;
-  const setCurrentKey = provider === "groq" ? setGroqKey : setOpenaiKey;
+  const currentKey = provider === "groq" ? groqKey : provider === "openai" ? openaiKey : customKey;
+  const setCurrentKey = provider === "groq" ? setGroqKey : provider === "openai" ? setOpenaiKey : setCustomKey;
 
   const handleSave = async () => {
     localStorage.setItem("wisper_groq_key", groqKey);
     localStorage.setItem("wisper_openai_key", openaiKey);
+    localStorage.setItem("wisper_custom_key", customKey);
+    localStorage.setItem("wisper_custom_url", customUrl);
+    localStorage.setItem("wisper_custom_model", customModel);
     localStorage.setItem("wisper_provider", provider);
-    localStorage.setItem(
-      "wisper_api_key",
-      provider === "groq" ? groqKey : openaiKey,
-    );
 
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
@@ -35,10 +40,6 @@ function Settings() {
 
   const handleProviderChange = (newProvider: Provider) => {
     setProvider(newProvider);
-    localStorage.setItem(
-      "wisper_api_key",
-      newProvider === "groq" ? groqKey : openaiKey,
-    );
     localStorage.setItem("wisper_provider", newProvider);
   };
 
@@ -83,6 +84,16 @@ function Settings() {
               >
                 OpenAI
               </button>
+              <button
+                onClick={() => handleProviderChange("custom")}
+                className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-all ${
+                  provider === "custom"
+                    ? "bg-primary-500 text-white"
+                    : "bg-white/5 text-white/60 hover:bg-white/10"
+                }`}
+              >
+                Custom
+              </button>
             </div>
           </div>
 
@@ -95,7 +106,7 @@ function Settings() {
                 type={showPassword ? "text" : "password"}
                 value={currentKey}
                 onChange={(e) => setCurrentKey(e.target.value)}
-                placeholder={provider === "groq" ? "gsk_..." : "sk-..."}
+                placeholder={provider === "groq" ? "gsk_..." : provider === "openai" ? "sk-..." : "Bearer token..."}
                 className="w-full bg-white/5 border border-white/10 rounded-lg pl-3 pr-10 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-primary-500"
               />
               <button
@@ -116,6 +127,31 @@ function Settings() {
               </button>
             </div>
           </div>
+
+          {provider === "custom" && (
+            <div className="p-3 bg-white/5 rounded-xl border border-white/5 space-y-2">
+              <div>
+                <label className="block text-white/70 text-xs font-medium mb-1">API URL</label>
+                <input
+                  type="text"
+                  value={customUrl}
+                  onChange={(e) => setCustomUrl(e.target.value)}
+                  placeholder="https://your-server/v1/audio/transcriptions"
+                  className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-primary-500"
+                />
+              </div>
+              <div>
+                <label className="block text-white/70 text-xs font-medium mb-1">Model name</label>
+                <input
+                  type="text"
+                  value={customModel}
+                  onChange={(e) => setCustomModel(e.target.value)}
+                  placeholder="whisper-1"
+                  className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-primary-500"
+                />
+              </div>
+            </div>
+          )}
 
           <div className="p-3 bg-white/5 rounded-xl border border-white/5">
             <div className="flex items-center gap-2 text-white/60 text-xs">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -8,7 +8,7 @@ const SHORTCUT_OPTIONS = [
   "Ctrl+Shift+Space",
   "Ctrl+Shift+Insert",
   "Alt+F12",
-];
+]; // Note: ScrollLock, Super key, and ContextMenu key combos don't work
 
 function Settings() {
   const [groqKey, setGroqKey] = useState("");

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -2,10 +2,19 @@ import { useState, useEffect } from "react";
 
 type Provider = "groq" | "openai";
 
+const SHORTCUT_OPTIONS = [
+  "Shift+Space",
+  "Ctrl+Alt+Space",
+  "Ctrl+Shift+Space",
+  "Ctrl+Shift+Insert",
+  "Alt+F12",
+];
+
 function Settings() {
   const [groqKey, setGroqKey] = useState("");
   const [openaiKey, setOpenaiKey] = useState("");
   const [provider, setProvider] = useState<Provider>("groq");
+  const [shortcut, setShortcut] = useState("Shift+Space");
   const [saved, setSaved] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -15,6 +24,7 @@ function Settings() {
     setProvider(
       (localStorage.getItem("wisper_provider") as Provider) || "groq",
     );
+    setShortcut(localStorage.getItem("wisper_shortcut") || "Shift+Space");
   }, []);
 
   const currentKey = provider === "groq" ? groqKey : openaiKey;
@@ -28,6 +38,10 @@ function Settings() {
       "wisper_api_key",
       provider === "groq" ? groqKey : openaiKey,
     );
+    localStorage.setItem("wisper_shortcut", shortcut);
+    if (window.electronAPI) {
+      window.electronAPI.updateShortcut(shortcut);
+    }
 
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
@@ -118,12 +132,20 @@ function Settings() {
           </div>
 
           <div className="p-3 bg-white/5 rounded-xl border border-white/5">
-            <div className="flex items-center gap-2 text-white/60 text-xs">
-              <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-white/70">Shift</kbd>
-              <span>+</span>
-              <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-white/70">Space</kbd>
-              <span>to record</span>
-            </div>
+            <label className="block text-white/70 text-xs font-medium mb-2">
+              Shortcut
+            </label>
+            <select
+              value={shortcut}
+              onChange={(e) => setShortcut(e.target.value)}
+              className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-primary-500 appearance-none cursor-pointer"
+            >
+              {SHORTCUT_OPTIONS.map((opt) => (
+                <option key={opt} value={opt} className="bg-gray-800">
+                  {opt}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -36,7 +36,8 @@ function Settings() {
   const currentKey = provider === "groq" ? groqKey : provider === "openai" ? openaiKey : customKey;
   const setCurrentKey = provider === "groq" ? setGroqKey : provider === "openai" ? setOpenaiKey : setCustomKey;
 
-  const handleSave = async () => {
+  const handleSave = async (e?: React.FormEvent) => {
+    e?.preventDefault();
     localStorage.setItem("wisper_groq_key", groqKey);
     localStorage.setItem("wisper_openai_key", openaiKey);
     localStorage.setItem("wisper_custom_key", customKey);
@@ -59,7 +60,7 @@ function Settings() {
 
   return (
     <div className="min-h-screen bg-dark-400 text-white p-4">
-      <div className="max-w-sm mx-auto">
+      <form onSubmit={handleSave} className="max-w-sm mx-auto">
         <div className="flex items-center justify-center gap-3 mb-4">
           <div className="w-8 h-8 rounded-full bg-primary-500 flex items-center justify-center shadow-lg shadow-primary-500/20">
             <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
@@ -79,6 +80,7 @@ function Settings() {
             </label>
             <div className="flex gap-2">
               <button
+                type="button"
                 onClick={() => handleProviderChange("groq")}
                 className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-all ${
                   provider === "groq"
@@ -89,6 +91,7 @@ function Settings() {
                 Groq
               </button>
               <button
+                type="button"
                 onClick={() => handleProviderChange("openai")}
                 className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-all ${
                   provider === "openai"
@@ -99,6 +102,7 @@ function Settings() {
                 OpenAI
               </button>
               <button
+                type="button"
                 onClick={() => handleProviderChange("custom")}
                 className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-all ${
                   provider === "custom"
@@ -186,7 +190,7 @@ function Settings() {
         </div>
 
         <button
-          onClick={handleSave}
+          type="submit"
           className={`w-full mt-4 py-2.5 px-4 rounded-lg font-medium text-sm transition-all ${
             saved
               ? "bg-green-500 text-white"
@@ -197,7 +201,7 @@ function Settings() {
         </button>
 
         <p className="mt-4 text-center text-white/25 text-xs">v1.1.0</p>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -105,7 +105,7 @@ export function Waveform({ audioLevel, isRecording, onClick }: WaveformProps) {
       className="flex items-center justify-center py-2 cursor-pointer"
       onClick={onClick}
     >
-      <canvas ref={canvasRef} width={150} height={48} />
+      <canvas ref={canvasRef} width={160} height={60} />
     </div>
   );
 }

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -80,7 +80,7 @@ export function Waveform({ audioLevel, isRecording, onClick }: WaveformProps) {
         const x = startX + i * (barWidth + gap);
         const y = centerY - smoothedHeight / 2;
 
-        ctx.fillStyle = isSpeaking ? primaryColor : "rgba(255, 255, 255, 0.25)";
+        ctx.fillStyle = isRecording ? primaryColor : "rgba(255, 255, 255, 0.25)";
         ctx.beginPath();
         if (ctx.roundRect) {
           ctx.roundRect(x, y, barWidth, smoothedHeight, 10);

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 
 interface AudioRecorderState {
   isRecording: boolean;
@@ -18,28 +18,82 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
   const audioChunksRef = useRef<Blob[]>([]);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const animationFrameRef = useRef<number>(0);
+  const isMonitoringRef = useRef(false);
   const audioContextRef = useRef<AudioContext | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const streamSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const resolveStopRef = useRef<((blob: Blob | null) => void) | null>(null);
+  const mimeTypeRef = useRef<string>("");
+
+  // Create AudioContext and AnalyserNode once on mount — no mic acquired, no OS recording indicator
+  useEffect(() => {
+    const audioContext = new AudioContext();
+    audioContextRef.current = audioContext;
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 256;
+    analyserRef.current = analyser;
+
+    // Cache MIME type detection once
+    let mimeType = "audio/webm;codecs=opus";
+    if (!MediaRecorder.isTypeSupported(mimeType)) {
+      mimeType = "audio/webm";
+      if (!MediaRecorder.isTypeSupported(mimeType)) {
+        mimeType = "audio/ogg;codecs=opus";
+        if (!MediaRecorder.isTypeSupported(mimeType)) {
+          mimeType = "";
+        }
+      }
+    }
+    mimeTypeRef.current = mimeType;
+
+    return () => {
+      isMonitoringRef.current = false;
+      audioContext.close();
+    };
+  }, []);
+
+  const playChime = useCallback((frequency: number) => {
+    const ctx = audioContextRef.current;
+    if (!ctx) return;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = "sine";
+    osc.frequency.value = frequency;
+    const now = ctx.currentTime;
+    gain.gain.setValueAtTime(0, now);
+    gain.gain.linearRampToValueAtTime(0.25, now + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.18);
+    osc.start(now);
+    osc.stop(now + 0.18);
+  }, []);
 
   const startRecording = useCallback(async () => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
 
-      // Set up audio analyser for waveform
-      const audioContext = new AudioContext();
-      audioContextRef.current = audioContext;
+      const audioContext = audioContextRef.current!;
+      const analyser = analyserRef.current!;
+
+      // AudioContext may be suspended; resume before playing chime or connecting source
+      if (audioContext.state === "suspended") {
+        await audioContext.resume();
+      }
+
+      playChime(880);
+
+      // Connect stream to the persistent AnalyserNode
       const source = audioContext.createMediaStreamSource(stream);
-      const analyser = audioContext.createAnalyser();
-      analyser.fftSize = 256;
       source.connect(analyser);
-      analyserRef.current = analyser;
+      streamSourceRef.current = source;
 
       // Start monitoring audio level
       const dataArray = new Uint8Array(analyser.frequencyBinCount);
+      isMonitoringRef.current = true;
       const updateLevel = () => {
-        if (analyserRef.current) {
+        if (isMonitoringRef.current && analyserRef.current) {
           analyserRef.current.getByteFrequencyData(dataArray);
           const avg = dataArray.reduce((a, b) => a + b) / dataArray.length;
           setAudioLevel(avg / 255);
@@ -48,18 +102,7 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
       };
       updateLevel();
 
-      // Detect best available MIME type
-      let mimeType = "audio/webm;codecs=opus";
-      if (!MediaRecorder.isTypeSupported(mimeType)) {
-        mimeType = "audio/webm";
-        if (!MediaRecorder.isTypeSupported(mimeType)) {
-          mimeType = "audio/ogg;codecs=opus";
-          if (!MediaRecorder.isTypeSupported(mimeType)) {
-            mimeType = "";
-          }
-        }
-      }
-
+      const mimeType = mimeTypeRef.current;
       const mediaRecorder = mimeType
         ? new MediaRecorder(stream, { mimeType })
         : new MediaRecorder(stream);
@@ -77,7 +120,6 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
         const audioBlob = new Blob(audioChunksRef.current, {
           type: actualMimeType,
         });
-
         if (resolveStopRef.current) {
           resolveStopRef.current(audioBlob);
           resolveStopRef.current = null;
@@ -91,35 +133,38 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
       console.error("Failed to start recording:", err);
       throw err;
     }
-  }, []);
+  }, [playChime]);
 
   const stopRecording = useCallback((): Promise<Blob | null> => {
     return new Promise((resolve) => {
       if (mediaRecorderRef.current && isRecording) {
         resolveStopRef.current = resolve;
 
+        playChime(660);
+
+        isMonitoringRef.current = false;
+        cancelAnimationFrame(animationFrameRef.current);
+        setAudioLevel(0);
+
+        // Disconnect stream source before stopping tracks
+        streamSourceRef.current?.disconnect();
+        streamSourceRef.current = null;
+
         mediaRecorderRef.current.stop();
         setIsRecording(false);
-        setAudioLevel(0);
-        cancelAnimationFrame(animationFrameRef.current);
-        analyserRef.current = null;
 
-        // Stop all tracks
+        // Stop mic tracks — releases the device and OS recording indicator
         if (streamRef.current) {
           streamRef.current.getTracks().forEach((track) => track.stop());
           streamRef.current = null;
         }
 
-        // Close AudioContext
-        if (audioContextRef.current) {
-          audioContextRef.current.close();
-          audioContextRef.current = null;
-        }
+        // AudioContext and AnalyserNode stay alive for next recording
       } else {
         resolve(null);
       }
     });
-  }, [isRecording]);
+  }, [isRecording, playChime]);
 
   return {
     isRecording,

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -82,26 +82,14 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
         await audioContext.resume();
       }
 
-      playChime(880);
-
       // Connect stream to the persistent AnalyserNode
       const source = audioContext.createMediaStreamSource(stream);
       source.connect(analyser);
       streamSourceRef.current = source;
 
-      // Start monitoring audio level
-      const dataArray = new Uint8Array(analyser.frequencyBinCount);
-      isMonitoringRef.current = true;
-      const updateLevel = () => {
-        if (isMonitoringRef.current && analyserRef.current) {
-          analyserRef.current.getByteFrequencyData(dataArray);
-          const avg = dataArray.reduce((a, b) => a + b) / dataArray.length;
-          setAudioLevel(avg / 255);
-          animationFrameRef.current = requestAnimationFrame(updateLevel);
-        }
-      };
-      updateLevel();
-
+      // Start MediaRecorder immediately — codec must be running before speech arrives.
+      // Starting it here (before the warmup delay) gives the Opus encoder time to
+      // fully initialize; any leading silence is harmless for Whisper.
       const mimeType = mimeTypeRef.current;
       const mediaRecorder = mimeType
         ? new MediaRecorder(stream, { mimeType })
@@ -128,6 +116,43 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
 
       mediaRecorderRef.current = mediaRecorder;
       mediaRecorder.start(100);
+
+      // Start monitoring audio level
+      const dataArray = new Uint8Array(analyser.frequencyBinCount);
+      isMonitoringRef.current = true;
+      const updateLevel = () => {
+        if (isMonitoringRef.current && analyserRef.current) {
+          analyserRef.current.getByteFrequencyData(dataArray);
+          const avg = dataArray.reduce((a, b) => a + b) / dataArray.length;
+          setAudioLevel(avg / 255);
+          animationFrameRef.current = requestAnimationFrame(updateLevel);
+        }
+      };
+      updateLevel();
+
+      // Wait until the mic is delivering real audio AND at least 300 ms have elapsed.
+      // The 300 ms floor covers both hardware warmup and codec initialization time.
+      // The analyser check (noise floor > 0) is a secondary gate; on its own it fires
+      // too fast (first-frame noise), so the timer dominates on cold start.
+      await Promise.all([
+        new Promise<void>(resolve => setTimeout(resolve, 300)),
+        new Promise<void>(resolve => {
+          const warmupData = new Uint8Array(analyser.frequencyBinCount);
+          const deadline = setTimeout(resolve, 500);
+          const check = () => {
+            analyser.getByteFrequencyData(warmupData);
+            if (warmupData.some(v => v > 0)) {
+              clearTimeout(deadline);
+              resolve();
+            } else {
+              requestAnimationFrame(check);
+            }
+          };
+          requestAnimationFrame(check);
+        }),
+      ]);
+
+      playChime(880);       // signals "mic is live, speak now"
       setIsRecording(true);
     } catch (err) {
       console.error("Failed to start recording:", err);

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -71,7 +71,13 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
 
   const startRecording = useCallback(async () => {
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: false,
+          // noiseSuppression: false,  // Keep noise suppression (on by default)
+          autoGainControl: false,
+        },
+      });
       streamRef.current = stream;
 
       const audioContext = audioContextRef.current!;
@@ -97,11 +103,19 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
 
       audioChunksRef.current = [];
 
-      mediaRecorder.ondataavailable = (event) => {
-        if (event.data.size > 0) {
-          audioChunksRef.current.push(event.data);
-        }
-      };
+      // Resolve when the first encoded chunk arrives — proves full pipeline readiness.
+      const firstChunkReady = new Promise<void>((resolve) => {
+        let resolved = false;
+        mediaRecorder.ondataavailable = (event) => {
+          if (event.data.size > 0) {
+            audioChunksRef.current.push(event.data);
+            if (!resolved) {
+              resolved = true;
+              resolve();
+            }
+          }
+        };
+      });
 
       mediaRecorder.onstop = () => {
         const actualMimeType = mediaRecorder.mimeType || "audio/webm";
@@ -130,29 +144,16 @@ export function useAudioRecorder(): UseAudioRecorderReturn {
       };
       updateLevel();
 
-      // Wait until the mic is delivering real audio AND at least 300 ms have elapsed.
-      // The 300 ms floor covers both hardware warmup and codec initialization time.
-      // The analyser check (noise floor > 0) is a secondary gate; on its own it fires
-      // too fast (first-frame noise), so the timer dominates on cold start.
-      await Promise.all([
-        new Promise<void>(resolve => setTimeout(resolve, 300)),
-        new Promise<void>(resolve => {
-          const warmupData = new Uint8Array(analyser.frequencyBinCount);
-          const deadline = setTimeout(resolve, 500);
-          const check = () => {
-            analyser.getByteFrequencyData(warmupData);
-            if (warmupData.some(v => v > 0)) {
-              clearTimeout(deadline);
-              resolve();
-            } else {
-              requestAnimationFrame(check);
-            }
-          };
-          requestAnimationFrame(check);
-        }),
+      // Wait for end-to-end readiness: first encoded audio chunk must arrive.
+      // Adaptive: fast mics ~100ms, slow USB mics ~200–800ms.
+      // 2s timeout is a safety net for broken mics.
+      await Promise.race([
+        firstChunkReady,
+        new Promise<void>((resolve) => setTimeout(resolve, 2000)),
       ]);
 
       playChime(880);       // signals "mic is live, speak now"
+      audioChunksRef.current = audioChunksRef.current.slice(0, 1); // keep header chunk, discard remaining warmup
       setIsRecording(true);
     } catch (err) {
       console.error("Failed to start recording:", err);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -15,6 +15,7 @@ declare global {
       resizeWindow: (width: number, height: number) => void;
       onOpenSettings: (callback: () => void) => void;
       removeAllListeners: (channel: string) => void;
+      saveDebugAudio: (arrayBuffer: ArrayBuffer, mimeType: string) => Promise<string | null>;
     };
   }
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -14,6 +14,7 @@ declare global {
       hideWindow: () => Promise<void>;
       resizeWindow: (width: number, height: number) => void;
       onOpenSettings: (callback: () => void) => void;
+      updateShortcut: (shortcut: string) => Promise<boolean>;
       removeAllListeners: (channel: string) => void;
     };
   }


### PR DESCRIPTION
Hi, I was excited about this project and got started working right away!

This PR includes:
 - Custom API selection (issue #5)
 - Selection of hotkeys (Shift-Space, Ctrl-Alt-Space, Ctrl-Shift-Space, Ctrl-Shift-Insert, and Alt-F12)
 - Begin recording voice quicker after hotkey press by keeping AudioContext around between recordings
   - Also begin MediaRecording sooner to minimize delay before recording is available
   - Also turn off echo cancellation and auto gain control for the microphone. These aren't really necessary for this use case and AGC in particular contributes to startup delay.
 - Provide an audible cue when the recording is actually ready / recording. This can vary depending upon the type of microphone as well as the time since the last recording.
 - Provide a visual cue as well. Changes visualization slightly so that now the waveform is gray until recording is ready, and red from then on.
 - Recording does not indicate as ready until the first encoded audio chunk is actually available. So now the user shouldn't start talking too soon and have his recording (and output text) clipped at the beginning.
 - Only register globalShortcut on X11; also registering localShortcut in X11 was causing double-toggle when ending recording if the recordingbar had focus. (I have only tested on my machine, which is Linux Mint Cinnamon/X11)
 - Add a delay in ydotool before the first characters are sent. This is to prevent characters from being lost when the input focus is not ready. The time between characters (ie, the speed of character output) is also adjustable and may be worth exposing to users. It's set so it's fast but not so fast that you can't be reading it as it comes out. 
 - Also add a small delay to allow the desktop to return focus to the target app after the Recording bar closes before sending text through ydotool
 - Modified the RecordingBar window to be always open, rather than opening and closing for each recording. This mean that desktop sounds associated with open/close will no longer fire, reducing user confusion. Settings also ensure the recording bar does not appear as a normal app in the task-switcher. Always-on-top, visibility, and ignore-mouse-events are set to ensure the window doesn't interfere with other desktop activities
 - Make the recording bar and working indicators slightly larger and more prominent, adding a pill-shaped translucent background
 - Add a debug facility for saving audio recordings, currently disabled (set DEBUG_AUDIO=true)

I apologize for the whole glut of changes at once. I tried putting these changes on separate branches for separate PRs but they quickly built on each other and I ended up basically giving up on that, but if you prefer it would be possible to give you just the API option or the shortcut option eg.