### PR TITLE
CI: fix release workflow for Tauri v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: "11"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -50,18 +50,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build + release
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: src-tauri
-          configPath: src-tauri/tauri.conf.json
           tagName: v__VERSION__
           releaseName: Wisper v__VERSION__
           releaseBody: "See the assets below for the Linux packages (deb, rpm, AppImage)."
           releaseDraft: true
           prerelease: false
-          includeUpdater: true
+          uploadUpdaterJson: true
           args: ${{ matrix.args }}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "3.0.0",
   "description": "Turn your voice into text right on your device, with your privacy always in your hands.",
   "author": "Tarak Shaw <taraksh01@gmail.com>",
+  "engines": {
+    "node": "24",
+    "pnpm": "11"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Fix tauri-action version (v1), uploadUpdaterJson input, remove invalid configPath, pin pnpm 11, add engines field.