### PR TITLE
CI: build on ubuntu-24.04 (glibc fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-22.04
+          - platform: ubuntu-24.04
             args: ""
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Fixes linking error: undefined symbol __isoc23_strtoll (glibc 2.38+ needed, 22.04 has 2.35).