### PR TITLE
CI: add libappindicator3-dev for tray

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Linux build deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev libasound2-dev patchelf rpm
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev libasound2-dev libappindicator3-dev patchelf rpm
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Fixes Tauri CLI panic: Can't detect any appindicator library.