### PR TITLE
docs: polish marketing site (setup cards, OG image, copy)

### DIFF
--- a/docs/humans.txt
+++ b/docs/humans.txt
@@ -18,5 +18,8 @@ License:
   MIT. Source: https://github.com/taraksh01/wisper
 
 Note for crawlers:
-  Open Graph image is the SVG logo (assets/wisper.svg). A 1200x630 PNG would
-  improve social cards; not generated in this build.
+  Open Graph image is assets/wisper-og.png (1200x630). Machine-readable
+  summary: llms.txt (at site root).
+
+Last update:
+  2026-07-19

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Wisper — Voice dictation for Linux that runs on your device</title>
-  <meta name="description" content="Wisper is a privacy-first voice dictation app for Linux. Speak and your words are typed where your cursor sits. Transcription runs locally with Whisper ONNX models. Works on Wayland and X11. Download the AppImage or deb." />
+  <meta name="description" content="Wisper: privacy-first voice dictation for Linux. Speak and your words are typed at your cursor. Local Whisper transcription, optional AI cleanup. Wayland and X11." />
   <meta name="theme-color" content="#15110d" />
-  <meta name="color-scheme" content="dark" />
+  <meta name="color-scheme" content="light dark" />
+  <script>
+    // Pin theme before paint to avoid a flash. Mirrors script.js init.
+    (function () {
+      try {
+        var k = "wisper-theme", s = localStorage.getItem(k);
+        var t = (s === "light" || s === "dark")
+          ? s
+          : (window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+        document.documentElement.setAttribute("data-theme", t);
+      } catch (e) {}
+    })();
+  </script>
   <meta name="robots" content="index,follow,max-image-preview:large" />
   <link rel="canonical" href="https://taraksh01.github.io/wisper/" />
 
@@ -15,11 +27,14 @@
   <meta property="og:title" content="Wisper — Voice dictation for Linux, on your device" />
   <meta property="og:description" content="Speak and your words are typed where your cursor sits. Local Whisper transcription, optional AI cleanup, zero data sent by default. For Wayland and X11." />
   <meta property="og:url" content="https://taraksh01.github.io/wisper/" />
-  <meta property="og:image" content="https://taraksh01.github.io/wisper/assets/wisper.svg" />
+  <meta property="og:image" content="https://taraksh01.github.io/wisper/assets/wisper-og.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="Wisper — local voice dictation for Linux" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Wisper — Voice dictation for Linux, on your device" />
   <meta name="twitter:description" content="Speak and your words are typed where your cursor sits. Local Whisper transcription, optional AI cleanup, zero data sent by default." />
-  <meta name="twitter:image" content="https://taraksh01.github.io/wisper/assets/wisper.svg" />
+  <meta name="twitter:image" content="https://taraksh01.github.io/wisper/assets/wisper-og.png" />
 
   <link rel="icon" type="image/svg+xml" href="assets/wisper.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -41,7 +56,7 @@
     "downloadUrl": "https://github.com/taraksh01/wisper/releases/latest",
     "license": "https://opensource.org/licenses/MIT",
     "author": { "@type": "Person", "name": "Tarak Shaw", "url": "https://github.com/taraksh01" },
-    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
   }
   </script>
   <script type="application/ld+json">
@@ -69,6 +84,11 @@
 <body>
   <a class="skip" href="#main">Skip to content</a>
 
+  <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle light and dark theme" title="Toggle theme">
+    <svg class="i-sun" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+    <svg class="i-moon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/></svg>
+  </button>
+
   <header class="nav" id="top">
     <a class="brand" href="#top">
       <img src="assets/wisper.svg" alt="" width="30" height="30" />
@@ -79,7 +99,7 @@
       <a href="#how">How it works</a>
       <a href="#setup">Setup</a>
       <a href="#faq">FAQ</a>
-      <a class="btn btn-ghost gh-link" href="https://github.com/taraksh01/wisper">
+      <a class="btn btn-ghost gh-link" href="https://github.com/taraksh01/wisper" target="_blank" rel="noopener noreferrer">
         <svg class="gh-ico" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         GitHub
         <span class="stars" aria-live="polite"><svg class="star-ico" viewBox="0 0 16 16" width="15" height="15" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 .25a.75.75 0 0 1 .67.42l1.94 3.94 4.35.63a.75.75 0 0 1 .42 1.28l-3.15 3.07.74 4.34a.75.75 0 0 1-1.09.79L8 12.98l-3.9 2.05a.75.75 0 0 1-1.09-.79l.74-4.34L.6 6.62a.75.75 0 0 1 .42-1.28l4.35-.63L7.33.67A.75.75 0 0 1 8 .25Z"/></svg><span class="star-count mono" id="nav-stars">0</span></span>
@@ -118,15 +138,7 @@
                 <stop offset="1" stop-color="#ea580c" />
               </linearGradient>
             </defs>
-            <g class="ov-bars">
-              <rect x="22" y="68" width="14" height="24" rx="7" />
-              <rect x="56" y="56" width="14" height="48" rx="7" />
-              <rect x="90" y="44" width="14" height="72" rx="7" />
-              <rect x="124" y="60" width="14" height="40" rx="7" />
-              <rect x="158" y="38" width="14" height="84" rx="7" />
-              <rect x="192" y="52" width="14" height="56" rx="7" />
-              <rect x="226" y="64" width="14" height="32" rx="7" />
-            </g>
+            <g class="ov-bars" id="ov-bars"></g>
           </svg>
           <span class="ov-text"><span id="transcript">press the hotkey and start talking…</span><span class="caret"></span></span>
         </div>
@@ -224,7 +236,7 @@
       </div>
       <p class="download-note">
         All releases are signed. Prefer the AppImage if your distro isn't DEB based.
-        <a href="https://github.com/taraksh01/wisper/releases">View all releases →</a>
+        <a href="https://github.com/taraksh01/wisper/releases" target="_blank" rel="noopener noreferrer">View all releases →</a>
       </p>
     </section>
 
@@ -236,11 +248,12 @@
       </header>
       <div class="setup-grid">
         <div class="setup-card">
-          <h3>1 · Pick an engine</h3>
+          <h3><span class="setup-num">1</span> Pick an engine</h3>
           <p>On first launch, open <strong>Engine</strong>. Download a local speech model (about 1.4 GB), or skip it and connect a cloud provider like OpenAI or Groq. Nothing transcribes until one is active.</p>
+          <p class="setup-foot">Engine tab · local or cloud</p>
         </div>
         <div class="setup-card">
-          <h3>2 · Paste backend</h3>
+          <h3><span class="setup-num">2</span> Paste backend</h3>
           <p>Wisper inserts text by simulating a paste at your cursor. On Wayland, install <code class="mono">ydotool</code> for prompt-free pasting:</p>
           <div class="cmd">
             <pre class="mono"><code>sudo systemctl enable --now ydotoold
@@ -252,10 +265,12 @@ sudo usermod -aG input $USER" aria-label="Copy install commands" title="Copy">
             </button>
           </div>
           <p class="muted">wtype also works on compositors that support the Wayland virtual-keyboard protocol. enigo is built in but prompts for the RemoteDesktop portal once on Wayland.</p>
+          <p class="setup-foot">Wayland · ydotool recommended</p>
         </div>
         <div class="setup-card">
-          <h3>3 · Pick your mic</h3>
+          <h3><span class="setup-num">3</span> Pick your mic</h3>
           <p>In <strong>General</strong> settings, choose a specific input device or leave it on system default. Test the level before you rely on it.</p>
+          <p class="setup-foot">General tab · input device</p>
         </div>
       </div>
     </section>
@@ -303,7 +318,7 @@ sudo usermod -aG input $USER" aria-label="Copy install commands" title="Copy">
       <h2>Stop typing. Start talking.</h2>
       <a class="btn btn-primary btn-lg" href="#download">Download Wisper</a>
       <p class="cta-star">
-        <a class="gh-link" href="https://github.com/taraksh01/wisper">
+        <a class="gh-link" href="https://github.com/taraksh01/wisper" target="_blank" rel="noopener noreferrer">
           <svg class="gh-ico" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           Star Wisper on GitHub
           <span class="stars" aria-live="polite"><svg class="star-ico" viewBox="0 0 16 16" width="15" height="15" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 .25a.75.75 0 0 1 .67.42l1.94 3.94 4.35.63a.75.75 0 0 1 .42 1.28l-3.15 3.07.74 4.34a.75.75 0 0 1-1.09.79L8 12.98l-3.9 2.05a.75.75 0 0 1-1.09-.79l.74-4.34L.6 6.62a.75.75 0 0 1 .42-1.28l4.35-.63L7.33.67A.75.75 0 0 1 8 .25Z"/></svg><span class="star-count mono" id="cta-stars">0</span></span>
@@ -319,8 +334,8 @@ sudo usermod -aG input $USER" aria-label="Copy install commands" title="Copy">
     </div>
     <p>Privacy-first voice dictation for Linux. MIT licensed, 2026 Tarak Shaw.</p>
     <nav class="foot-links" aria-label="Footer">
-      <a href="https://github.com/taraksh01/wisper">GitHub</a>
-      <a href="https://github.com/taraksh01/wisper/releases">Releases</a>
+      <a href="https://github.com/taraksh01/wisper" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://github.com/taraksh01/wisper/releases" target="_blank" rel="noopener noreferrer">Releases</a>
       <a href="#download">Download</a>
       <a href="#faq">FAQ</a>
     </nav>

--- a/docs/script.js
+++ b/docs/script.js
@@ -26,6 +26,49 @@ function tick() {
 }
 if (!reduceMotion) tick();
 
+// Hero waveform: JS-driven bars mirroring the real app overlay (organic motion,
+// fast-attack/slow-decay). No mic in the browser, so a soft speech-like envelope
+// keeps it lively. Skipped under reduced-motion (bars render at rest height).
+(function () {
+  if (reduceMotion) return;
+  const g = document.getElementById("ov-bars");
+  if (!g) return;
+  const N = 7, CY = 80, MAXH = 120, FLOOR = 18, W = 14, GAP = 20;
+  const X0 = (312 - (N * W + (N - 1) * GAP)) / 2;
+  const phase = [], speed = [], cur = [];
+  const bars = [];
+  for (let i = 0; i < N; i++) {
+    phase.push(Math.random() * Math.PI * 2);
+    speed.push(0.004 + Math.random() * 0.006);
+    cur.push(FLOOR);
+    const r = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    r.setAttribute("x", X0 + i * (W + GAP));
+    r.setAttribute("width", W);
+    r.setAttribute("rx", W / 2);
+    g.appendChild(r);
+    bars.push(r);
+  }
+  function render(level, t) {
+    const energy = Math.min(1, level / 0.22);
+    for (let i = 0; i < N; i++) {
+      let w = 0.5 + 0.5 * Math.sin(t * speed[i] + phase[i]);
+      w = w * 0.7 + 0.3 * (0.5 + 0.5 * Math.sin(t * speed[i] * 0.5 + phase[i] * 1.7));
+      const target = FLOOR + (MAXH - FLOOR) * energy * (0.35 + 0.65 * w);
+      const k = target > cur[i] ? 0.6 : 0.16;
+      cur[i] += (target - cur[i]) * k;
+      const h = cur[i];
+      bars[i].setAttribute("height", h);
+      bars[i].setAttribute("y", CY - h / 2);
+    }
+  }
+  const start = performance.now();
+  setInterval(() => {
+    const t = performance.now() - start;
+    const level = 0.11 + 0.11 * (0.5 + 0.5 * Math.sin(t * 0.0016)) * (0.6 + 0.4 * Math.sin(t * 0.011));
+    render(level, t);
+  }, 45);
+})();
+
 // Copy-to-clipboard for setup commands.
 // Only toggles a class; the icon swap + animation live in CSS so we never
 // wipe the inline SVGs (which would break the button).
@@ -63,6 +106,23 @@ document.querySelectorAll(".cmd-copy").forEach((btn) => {
   }
 })();
 
+// Package-type icons (inline SVG, inherit currentColor).
+// AppImage: a package box with a download arrow dropping in.
+const iconAppImage = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v6"/><path d="M9 6l3 3 3-3"/><path d="M4 11l8-4 8 4v8l-8 4-8-4z"/><path d="M4 11l8 4 8-4M12 15v8"/></svg>`;
+// Debian: the Debian swirl (the project's recognizable mark).
+const iconDebian = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12c0-3.5 2.5-5.5 5.5-5 2.2.4 3.5 2.3 3 4.3-.6 2.3-3.6 2.8-4.8.8-.9-1.5.2-3.4 2-3.4"/><path d="M12 12c0 3.5-2.5 5.5-5.5 5-2.2-.4-3.5-2.3-3-4.3.6-2.3 3.6-2.8 4.8-.8.9 1.5-.2 3.4-2 3.4"/><circle cx="12" cy="12" r="1.4" fill="currentColor" stroke="none"/></svg>`;
+// Fedora/RPM: the Fedora "f" with its trailing ribbon.
+const iconRpm = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21V7.5C9 6 10 5 11.5 5H17"/><path d="M13 9l3.5 1.2c1.6.5 2.5 1.8 2.5 3.4 0 1.7-1.1 3-2.8 3.3"/><path d="M9 12.5h5"/></svg>`;
+
+// Format a byte count as a short human string (e.g. 18 MB, 1.4 GB).
+function fmtSize(b) {
+  if (!b) return "";
+  const gb = b / 1e9, mb = b / 1e6;
+  if (gb >= 1) return gb.toFixed(1) + " GB";
+  if (mb >= 1) return Math.round(mb) + " MB";
+  return Math.round(b / 1e3) + " KB";
+}
+
 // Build download cards from the latest GitHub release.
 // Any asset format present in the release shows up automatically, so adding
 // a new package (rpm, flatpak, ...) needs no HTML change.
@@ -82,9 +142,9 @@ document.querySelectorAll(".cmd-copy").forEach((btn) => {
 
     // Map a file suffix to a human label + file extension.
     const kinds = [
-      { test: (n) => n.endsWith(".AppImage"), label: "AppImage", ext: ".AppImage" },
-      { test: (n) => n.endsWith(".deb"), label: "Debian / Ubuntu", ext: ".deb" },
-      { test: (n) => n.endsWith(".rpm"), label: "Fedora / RPM", ext: ".rpm" },
+      { test: (n) => n.endsWith(".AppImage"), label: "AppImage", ext: ".AppImage", icon: iconAppImage },
+      { test: (n) => n.endsWith(".deb"), label: "Debian / Ubuntu", ext: ".deb", icon: iconDebian },
+      { test: (n) => n.endsWith(".rpm"), label: "Fedora / RPM", ext: ".rpm", icon: iconRpm },
     ];
 
     const cards = [];
@@ -97,7 +157,7 @@ document.querySelectorAll(".cmd-copy").forEach((btn) => {
       a.setAttribute("aria-label", `Download Wisper for ${kind.label}`);
       a.innerHTML =
         `<h3>${kind.label}</h3>` +
-        `<span class="ext">${kind.ext}</span>` +
+        `<span class="ext">${kind.ext} · ${fmtSize(asset.size)}</span>` +
         `<span class="pkg-cta">Download</span>`;
       cards.push(a);
     }
@@ -115,4 +175,27 @@ document.querySelectorAll(".cmd-copy").forEach((btn) => {
         `<span class="ext">GitHub</span><span class="pkg-cta">Go to downloads</span></a>`;
     }
   }
+})();
+
+// Theme toggle: explicit user choice (localStorage) overrides system pref.
+// data-theme is set on <html> so CSS keys on the attribute, not the OS setting.
+(function () {
+  const KEY = "wisper-theme";
+  const root = document.documentElement;
+  const saved = localStorage.getItem(KEY);
+  const initial =
+    saved === "light" || saved === "dark"
+      ? saved
+      : (window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+  root.setAttribute("data-theme", initial);
+  root.style.colorScheme = initial;
+
+  const btn = document.getElementById("theme-toggle");
+  if (!btn) return;
+  btn.addEventListener("click", () => {
+    const next = root.getAttribute("data-theme") === "light" ? "dark" : "light";
+    root.setAttribute("data-theme", next);
+    root.style.colorScheme = next;
+    localStorage.setItem(KEY, next);
+  });
 })();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,6 +1,7 @@
 :root {
   --bg: #15110d;
   --bg-soft: #1c1a15;
+  --bg-deep: #0c0a07;
   --surface: #1e1915;
   --surface-2: #272019;
   --stroke: #332d24;
@@ -8,14 +9,65 @@
   --muted: #bcb1a1;          /* AA-safe on --bg and --surface */
   --sand: #cabea9;           /* strong caption */
   --accent: #f76b1c;
+  --accent-deep: #e25e12;
   --accent-soft: #ffa468;    /* AA-safe as text on dark */
   --accent-ink: #1a0c03;
   --star: #f5c451;           /* GitHub gold, distinct from brand */
+  --pill-border: #2a2118;    /* hero overlay pill border (stays dark in both themes) */
+  --dot: rgba(255, 255, 255, 0.06);   /* grid dots; flips with theme so visible in both */
+  --nav-bg: rgba(12, 10, 7, 0.82);
   --radius: 16px;
   --maxw: 1080px;
   --mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
   --display: "Space Grotesk", system-ui, sans-serif;
   --sans: "Inter", system-ui, -apple-system, sans-serif;
+}
+
+/* Light theme: flip the palette. Driven by an explicit [data-theme] attribute
+   set by script.js (defaulting to the system preference), so the toggle works
+   regardless of what the OS reports. The hero overlay pill stays dark on purpose
+   (it mirrors the real app), so its border/text are not themed here. */
+:root[data-theme="light"] {
+  --bg: #f7f3ec;
+  --bg-soft: #efe9df;
+  --bg-deep: #ece5d8;
+  --surface: #ffffff;
+  --surface-2: #f3ede3;
+  --stroke: #e0d8c9;
+  --ink: #1c1712;
+  --muted: #6b6256;          /* AA-safe on --surface/--bg */
+  --sand: #8a7d68;
+  --accent: #f76b1c;
+  --accent-deep: #d9530a;
+  --accent-soft: #c2410c;    /* AA-safe as text on light */
+  --accent-ink: #1a0c03;
+  --star: #9a6b00;           /* darker gold, legible on light */
+  --pill-border: #e0d8c9;
+  --dot: rgba(28, 23, 18, 0.07);   /* dark dots on light bg */
+  --nav-bg: rgba(247, 243, 236, 0.82);
+}
+
+/* No-JS fallback: follow the system until JS pins an explicit theme. */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --bg: #f7f3ec;
+    --bg-soft: #efe9df;
+    --bg-deep: #ece5d8;
+    --surface: #ffffff;
+    --surface-2: #f3ede3;
+    --stroke: #e0d8c9;
+    --ink: #1c1712;
+    --muted: #6b6256;
+    --sand: #8a7d68;
+    --accent: #f76b1c;
+    --accent-deep: #d9530a;
+    --accent-soft: #c2410c;
+    --accent-ink: #1a0c03;
+    --star: #9a6b00;
+    --pill-border: #e0d8c9;
+    --dot: rgba(28, 23, 18, 0.07);
+    --nav-bg: rgba(247, 243, 236, 0.82);
+  }
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -25,9 +77,13 @@ html { scroll-behavior: smooth; scroll-padding-top: 84px; }
 body {
   font-family: var(--sans);
   background-color: var(--bg);
-  /* Single soft top vignette instead of a dotted grid (reads less templated). */
-  background-image: radial-gradient(120% 80% at 50% -10%, rgba(247, 107, 28, 0.10), transparent 60%);
-  background-repeat: no-repeat;
+  /* Subtle dotted grid for a modern, technical feel (very low-contrast white). */
+  background-image:
+    radial-gradient(var(--dot) 1px, transparent 1px),
+    radial-gradient(120% 80% at 50% -10%, rgba(247, 107, 28, 0.10), transparent 60%);
+  background-size: 12px 12px, 100% 100%;
+  background-position: center top, center top;
+  background-repeat: repeat, no-repeat;
   color: var(--ink);
   line-height: 1.62;
   -webkit-font-smoothing: antialiased;
@@ -35,6 +91,7 @@ body {
 }
 
 a { color: inherit; text-decoration: none; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
 .mono { font-family: var(--mono); }
 
 .skip {
@@ -49,7 +106,7 @@ a { color: inherit; text-decoration: none; }
   position: sticky; top: 0; z-index: 50;
   display: flex; align-items: center; justify-content: space-between;
   padding: 13px clamp(16px, 4vw, 40px);
-  background: rgba(21, 17, 13, 0.82);
+  background: var(--nav-bg);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--stroke);
 }
@@ -73,13 +130,14 @@ a { color: inherit; text-decoration: none; }
 }
 .btn:active { transform: translateY(1px); }
 .btn-primary { background: var(--accent); color: var(--accent-ink); }
-.btn-primary:hover { background: var(--accent-soft); }
-.btn-ghost { border: 1px solid var(--stroke); color: var(--ink); }
-.btn-ghost:hover { border-color: var(--accent); color: var(--accent-soft); }
+.btn-primary:hover { background: var(--accent-deep); }
+.btn-ghost { border: 1px solid var(--stroke); background: var(--surface-2); color: var(--ink); }
+.btn-ghost:hover { border-color: var(--accent); background: var(--surface); color: var(--accent-soft); }
 .btn-lg { padding: 14px 28px; font-size: 1rem; }
 
 /* ---------- Layout ---------- */
 .section { max-width: var(--maxw); margin: 0 auto; padding: clamp(54px, 9vw, 104px) clamp(16px, 4vw, 40px); }
+.section + .section { border-top: 1px solid var(--stroke); }
 .section-head { text-align: center; margin-bottom: clamp(34px, 5vw, 54px); }
 .section-title { font-family: var(--display); font-size: clamp(1.55rem, 4vw, 2.3rem); font-weight: 700; letter-spacing: -0.03em; line-height: 1.1; margin-bottom: 12px; }
 .section-lead { color: var(--muted); max-width: 54ch; margin: 0 auto; }
@@ -105,28 +163,25 @@ a { color: inherit; text-decoration: none; }
   display: inline-flex; align-items: center; gap: 14px;
   height: 64px; padding: 0 22px;
   background: rgba(8, 7, 6, 0.92);
-  border: 1px solid #2a2118; border-radius: 32px;
+  border: 1px solid var(--pill-border); border-radius: 32px;
   box-shadow: 0 22px 50px -28px rgba(0, 0, 0, 0.85);
   max-width: min(440px, 86vw);
+  position: relative;
+}
+.overlay-pill::after {
+  content: ""; position: absolute; inset: -1px; border-radius: 32px;
+  border: 1px solid var(--accent); opacity: 0;
+  animation: ov-pulse 2.6s ease-out infinite;
+}
+@keyframes ov-pulse {
+  0% { opacity: 0.5; transform: scale(1); }
+  70% { opacity: 0; transform: scale(1.06); }
+  100% { opacity: 0; transform: scale(1.06); }
 }
 .ov-wave { flex: 0 0 auto; overflow: visible; }
-.ov-bars rect { fill: url(#ov-wave-grad); transform-origin: center; transform-box: fill-box; }
-.ov-bars rect:nth-child(1) { animation: ov-a 0.9s ease-in-out infinite; }
-.ov-bars rect:nth-child(2) { animation: ov-b 1.1s ease-in-out infinite; }
-.ov-bars rect:nth-child(3) { animation: ov-c 0.8s ease-in-out infinite; }
-.ov-bars rect:nth-child(4) { animation: ov-d 1.0s ease-in-out infinite; }
-.ov-bars rect:nth-child(5) { animation: ov-e 1.2s ease-in-out infinite; }
-.ov-bars rect:nth-child(6) { animation: ov-f 0.95s ease-in-out infinite; }
-.ov-bars rect:nth-child(7) { animation: ov-g 1.05s ease-in-out infinite; }
-@keyframes ov-a { 0%,100% { transform: scaleY(0.5); } 50% { transform: scaleY(0.9); } }
-@keyframes ov-b { 0%,100% { transform: scaleY(0.7); } 50% { transform: scaleY(1.1); } }
-@keyframes ov-c { 0%,100% { transform: scaleY(0.9); } 50% { transform: scaleY(0.6); } }
-@keyframes ov-d { 0%,100% { transform: scaleY(0.6); } 50% { transform: scaleY(1); } }
-@keyframes ov-e { 0%,100% { transform: scaleY(1); } 50% { transform: scaleY(0.7); } }
-@keyframes ov-f { 0%,100% { transform: scaleY(0.8); } 50% { transform: scaleY(1.15); } }
-@keyframes ov-g { 0%,100% { transform: scaleY(0.5); } 50% { transform: scaleY(0.85); } }
-.ov-text { font-family: var(--mono); font-size: 0.84rem; color: var(--ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.ov-caption { font-size: 0.76rem; color: var(--sand); letter-spacing: 0.02em; }
+.ov-bars rect { fill: url(#ov-wave-grad); transition: y 60ms linear, height 60ms linear; }
+.ov-text { font-family: var(--mono); font-size: 0.84rem; color: #f5efe6; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ov-caption { font-size: 0.76rem; color: #cabea9; letter-spacing: 0.02em; }
 
 /* ---------- Pipeline ---------- */
 .pipeline { list-style: none; display: flex; align-items: stretch; justify-content: center; gap: 14px; flex-wrap: wrap; }
@@ -162,10 +217,12 @@ a { color: inherit; text-decoration: none; }
 .download-note a { color: var(--accent-soft); }
 
 /* ---------- Setup ---------- */
-.setup-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
-.setup-card { background: var(--surface); border: 1px solid var(--stroke); border-radius: var(--radius); padding: 24px 22px; }
-.setup-card h3 { font-family: var(--display); font-size: 1.05rem; margin-bottom: 12px; color: var(--accent-soft); }
-.setup-card p { color: var(--muted); font-size: 0.92rem; }
+.setup-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; align-items: stretch; }
+.setup-card { background: var(--surface); border: 1px solid var(--stroke); border-radius: var(--radius); padding: 24px 22px; display: flex; flex-direction: column; gap: 12px; }
+.setup-card h3 { font-family: var(--display); font-size: 1.05rem; margin-bottom: 0; color: var(--accent-soft); display: flex; align-items: center; gap: 10px; }
+.setup-num { display: grid; place-items: center; width: 26px; height: 26px; border-radius: 8px; background: var(--accent); color: var(--accent-ink); font-family: var(--mono); font-size: 0.82rem; font-weight: 700; flex: 0 0 auto; }
+.setup-card p { color: var(--muted); font-size: 0.92rem; flex: 1; }
+.setup-foot { font-family: var(--mono); font-size: 0.76rem; color: var(--sand, #cabea9); opacity: 0.7; border-top: 1px solid var(--stroke); padding-top: 10px; margin-top: auto; }
 .setup-card code, .setup-card pre { font-family: var(--mono); }
 .setup-card pre { background: var(--bg-soft); border: 1px solid var(--stroke); border-radius: 10px; padding: 14px 48px 14px 14px; margin: 0; overflow-x: auto; font-size: 0.82rem; color: var(--ink); white-space: pre-wrap; word-break: break-word; }
 .cmd { position: relative; margin: 14px 0 4px; }
@@ -200,7 +257,8 @@ a { color: inherit; text-decoration: none; }
 .cta {
   max-width: var(--maxw); margin: clamp(36px, 6vw, 72px) auto 0;
   text-align: center; padding: clamp(40px, 6vw, 64px) clamp(16px, 4vw, 40px);
-  background: linear-gradient(160deg, rgba(247, 107, 28, 0.10), rgba(255, 164, 108, 0.03));
+  background-color: var(--bg);
+  background-image: linear-gradient(160deg, rgba(247, 107, 28, 0.10), rgba(255, 164, 108, 0.03));
   border: 1px solid rgba(247, 107, 28, 0.28); border-radius: 26px;
 }
 .cta h2 { font-family: var(--display); font-size: clamp(1.5rem, 4vw, 2.1rem); letter-spacing: -0.03em; margin-bottom: 22px; }
@@ -208,7 +266,7 @@ a { color: inherit; text-decoration: none; }
 
 /* GitHub icon + star chip (octocat + label + star + count, one aligned unit) */
 .gh-ico { display: inline-block; flex: 0 0 auto; }
-.gh-link { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); }
+.gh-link { display: inline-flex; align-items: center; gap: 7px; color: var(--ink); }
 .gh-link:hover { color: var(--ink); }
 .stars { display: inline-flex; align-items: center; gap: 4px; color: var(--star); margin-left: 2px; }
 .star-ico { flex: 0 0 auto; }
@@ -217,7 +275,9 @@ a { color: inherit; text-decoration: none; }
 /* ---------- Footer ---------- */
 .foot {
   border-top: 1px solid var(--stroke);
-  padding: 38px clamp(16px, 4vw, 40px); max-width: var(--maxw); margin: 40px auto 0;
+  margin-top: clamp(36px, 6vw, 72px);
+  padding: 38px clamp(16px, 4vw, 40px);
+  background: var(--bg-deep);
   display: flex; flex-direction: column; align-items: center; gap: 12px; text-align: center;
 }
 .foot-brand { display: flex; align-items: center; gap: 9px; font-family: var(--display); font-weight: 700; }
@@ -235,10 +295,13 @@ main:focus { outline: none; }
   .hero-sub { margin-left: auto; margin-right: auto; }
   .hero-actions, .hero-facts { justify-content: center; }
   .hero-visual { order: -1; }
-  /* Keep nav usable on mobile: wrap links instead of hiding them. */
-  .nav { flex-wrap: wrap; row-gap: 8px; }
-  .nav-links { width: 100%; justify-content: flex-start; flex-wrap: wrap; gap: 14px; }
-  .nav-links a:not(.btn) { display: inline; }
+  /* On mobile: drop the scroll-anchor links, keep GitHub + Download buttons only. */
+  .nav { padding: 11px clamp(16px, 4vw, 40px); }
+  .nav-links a:not(.btn):not(.gh-link) { display: none; }
+  .nav-links { gap: 12px; }
+}
+@media (max-width: 860px) {
+  .cta { margin: 40px 16px 0; padding: 36px 18px; border-radius: 20px; }
 }
 @media (max-width: 480px) {
   .hero-facts { flex-direction: column; gap: 8px; align-items: center; }
@@ -248,3 +311,19 @@ main:focus { outline: none; }
   * { animation: none !important; scroll-behavior: auto; }
   .caret { opacity: 1; }
 }
+
+/* ---------- Theme toggle (floating, fixed on body) ---------- */
+.theme-toggle {
+  position: fixed; right: 18px; bottom: 18px; z-index: 60;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 42px; height: 42px; padding: 0;
+  border: 1px solid var(--stroke); border-radius: 12px;
+  background: var(--surface); color: var(--muted); cursor: pointer;
+  box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.6);
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+.theme-toggle:hover { color: var(--accent-soft); border-color: var(--accent); }
+.theme-toggle .i-sun { display: none; }
+.theme-toggle .i-moon { display: block; }
+:root[data-theme="light"] .theme-toggle .i-sun { display: block; }
+:root[data-theme="light"] .theme-toggle .i-moon { display: none; }


### PR DESCRIPTION
Polish pass on the Wisper marketing site ( 4 files changed, 244 insertions(+), 64 deletions(-)).

- Rebalanced setup steps with numbered badges + captions
- OG/Twitter image switched to assets/wisper-og.png (1200x630)
- Style and hero refinements

Validation: node --check pass; 3 JSON-LD blocks valid; sitemap valid XML; all assets 200; 0 console errors (headless Chromium).