### PR TITLE
docs: show static waveform under reduced-motion

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -28,9 +28,8 @@ if (!reduceMotion) tick();
 
 // Hero waveform: JS-driven bars mirroring the real app overlay (organic motion,
 // fast-attack/slow-decay). No mic in the browser, so a soft speech-like envelope
-// keeps it lively. Skipped under reduced-motion (bars render at rest height).
+// keeps it lively. Under reduced-motion it renders a static bar set (no loop).
 (function () {
-  if (reduceMotion) return;
   const g = document.getElementById("ov-bars");
   if (!g) return;
   const N = 7, CY = 80, MAXH = 120, FLOOR = 18, W = 14, GAP = 20;
@@ -47,6 +46,11 @@ if (!reduceMotion) tick();
     r.setAttribute("rx", W / 2);
     g.appendChild(r);
     bars.push(r);
+  }
+  // Reduced-motion: render a static rest-height bar set, no animation loop.
+  if (reduceMotion) {
+    bars.forEach((b) => { b.setAttribute("height", FLOOR); b.setAttribute("y", CY - FLOOR / 2); });
+    return;
   }
   function render(level, t) {
     const energy = Math.min(1, level / 0.22);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -181,7 +181,7 @@ a { color: inherit; text-decoration: none; }
 .ov-wave { flex: 0 0 auto; overflow: visible; }
 .ov-bars rect { fill: url(#ov-wave-grad); transition: y 60ms linear, height 60ms linear; }
 .ov-text { font-family: var(--mono); font-size: 0.84rem; color: #f5efe6; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.ov-caption { font-size: 0.76rem; color: #cabea9; letter-spacing: 0.02em; }
+.ov-caption { font-size: 0.76rem; color: var(--sand); letter-spacing: 0.02em; }
 
 /* ---------- Pipeline ---------- */
 .pipeline { list-style: none; display: flex; align-items: stretch; justify-content: center; gap: 14px; flex-wrap: wrap; }


### PR DESCRIPTION
Reduced-motion users previously saw a blank hero pill (IIFE returned before creating bars). Now renders a static rest-height bar set with no animation loop. Also uses the --sand token for the caption color.

Validation: node --check pass; reduced-motion path sets height+y on 7 bars; no co-author.