### PR TITLE
feat: always-live mic preview with quality guidance and hardening

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -210,7 +210,8 @@ impl AudioRecorder {
     }
 
     pub fn start_recording(&self, device: Option<String>) -> Result<(), String> {
-        // Stop preview if active - don't hold two streams
+        // Stop preview if active - don't hold two streams; keep last level
+        // briefly to avoid flicker until recording callback produces new RMS.
         *self
             .preview_stream
             .lock()
@@ -219,7 +220,6 @@ impl AudioRecorder {
             .preview_device
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = None;
-        self.level.store(0, Ordering::Relaxed);
         let device = resolve_device(device.as_deref())?;
 
         let config = device
@@ -304,7 +304,16 @@ impl AudioRecorder {
         {
             return Ok(());
         }
-        // If preview already running with same device, keep it (idempotent)
+        // Resolve first so we can compare by the actual device identity (cpal may
+        // alias the same mic under hw/plughw/dsnoop). This avoids the stale-raw-id
+        // bug where switching from "hw:CARD=..." to "plughw:CARD=..." for the same
+        // mic would unnecessarily tear down and recreate.
+        let resolved = resolve_device(device.as_deref())?;
+        let resolved_id = resolved
+            .id()
+            .ok()
+            .map(|i| i.to_string())
+            .unwrap_or_else(|| resolved.to_string());
         {
             let cur_dev = self
                 .preview_device
@@ -316,10 +325,9 @@ impl AudioRecorder {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
                 .is_some();
-            if preview_active && cur_dev == device {
+            if preview_active && cur_dev.as_deref() == Some(resolved_id.as_str()) {
                 return Ok(());
             }
-            // Different device requested – tear down old stream so new device is used
             if preview_active {
                 *self
                     .preview_stream
@@ -331,8 +339,8 @@ impl AudioRecorder {
                     .unwrap_or_else(|e| e.into_inner()) = None;
             }
         }
-        let device_id_for_log = device.clone();
-        let device = resolve_device(device.as_deref())?;
+        let device_id_for_log = Some(resolved_id.clone());
+        let device = resolved;
         let config = device
             .default_input_config()
             .map_err(|e| format!("Failed to get input config: {}", e))?;

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -186,6 +186,7 @@ pub struct AudioRecorder {
     buffer: Arc<Mutex<Vec<f32>>>,
     stream: Arc<Mutex<Option<Stream>>>,
     preview_stream: Arc<Mutex<Option<Stream>>>,
+    preview_device: Arc<Mutex<Option<String>>>,
     sample_rate: Arc<Mutex<u32>>,
     /// Latest input RMS amplitude (f32 bits), updated live in the audio callback.
     level: Arc<AtomicU32>,
@@ -197,6 +198,7 @@ impl AudioRecorder {
             buffer: Arc::new(Mutex::new(Vec::new())),
             stream: Arc::new(Mutex::new(None)),
             preview_stream: Arc::new(Mutex::new(None)),
+            preview_device: Arc::new(Mutex::new(None)),
             sample_rate: Arc::new(Mutex::new(16000)),
             level: Arc::new(AtomicU32::new(0)),
         }
@@ -213,6 +215,11 @@ impl AudioRecorder {
             .preview_stream
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = None;
+        *self
+            .preview_device
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
+        self.level.store(0, Ordering::Relaxed);
         let device = resolve_device(device.as_deref())?;
 
         let config = device
@@ -288,14 +295,6 @@ impl AudioRecorder {
     /// Open the input stream to feed the live level meter without recording
     /// or transcribing. Used by the mic-test preview in settings.
     pub fn start_preview(&self, device: Option<String>) -> Result<(), String> {
-        if self
-            .preview_stream
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_some()
-        {
-            return Ok(());
-        }
         // Don't start preview if already recording - use separate slot
         if self
             .stream
@@ -305,6 +304,34 @@ impl AudioRecorder {
         {
             return Ok(());
         }
+        // If preview already running with same device, keep it (idempotent)
+        {
+            let cur_dev = self
+                .preview_device
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone();
+            let preview_active = self
+                .preview_stream
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_some();
+            if preview_active && cur_dev == device {
+                return Ok(());
+            }
+            // Different device requested – tear down old stream so new device is used
+            if preview_active {
+                *self
+                    .preview_stream
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+                *self
+                    .preview_device
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+            }
+        }
+        let device_id_for_log = device.clone();
         let device = resolve_device(device.as_deref())?;
         let config = device
             .default_input_config()
@@ -345,12 +372,20 @@ impl AudioRecorder {
             .preview_stream
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(stream);
+        *self
+            .preview_device
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = device_id_for_log;
         Ok(())
     }
 
     pub fn stop_preview(&self) {
         *self
             .preview_stream
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
+        *self
+            .preview_device
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = None;
         self.level.store(0, Ordering::Relaxed);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,15 +125,20 @@ fn get_input_level() -> f32 {
 }
 
 #[tauri::command]
-fn start_mic_preview() -> Result<(), String> {
-    let device = crate::coordinator::INPUT_DEVICE
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .clone();
-    let device = if device.is_empty() {
-        None
-    } else {
-        Some(device)
+fn start_mic_preview(device: Option<String>) -> Result<(), String> {
+    // Frontend may pass the currently-selected device explicitly so the meter
+    // reflects the dropdown choice immediately without waiting for the async
+    // settings save to propagate to INPUT_DEVICE. Fall back to the global when
+    // no explicit device is provided (backwards compat / system default).
+    let device = match device {
+        Some(d) if !d.is_empty() => Some(d),
+        _ => {
+            let g = crate::coordinator::INPUT_DEVICE
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone();
+            if g.is_empty() { None } else { Some(g) }
+        }
     };
     RECORDER
         .lock()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,10 +87,10 @@ function AppShell() {
     fetchHistory();
     fetchAgentProfiles();
     invoke<string>("get_current_state").then((v) => alive && setAppState(v)).catch((e) => { console.error(e); });
-    invoke<string>("get_current_model").then((v) => alive && setCurrentModelName(v)).catch(() => {});
+    invoke<string>("get_current_model").then((v) => alive && setCurrentModelName(v)).catch((e) => console.error("get_current_model failed:", e));
     invoke<{ reliable: boolean; has_wtype: boolean; has_ydotool: boolean }>("get_paste_environment", { preference: "auto" })
       .then((v) => alive && setPasteEnv(v))
-      .catch(() => {});
+      .catch((e) => console.error("get_paste_environment failed:", e));
 
     const unlistenStatePromise = listen<string>("wisper:state", (event) => {
       if (alive) setAppState(event.payload);
@@ -130,7 +130,9 @@ function AppShell() {
       setHistory(h);
       setStats(s);
       setHistoryTotal(c);
-    } catch {}
+    } catch (e) {
+      console.error("fetchHistory failed:", e);
+    }
   }, []);
 
   const loadOlder = useCallback(async () => {
@@ -142,7 +144,9 @@ function AppShell() {
         offset: history.length,
       });
       setHistory((prev) => [...prev, ...older]);
-    } catch {}
+    } catch (e) {
+      console.error("loadOlder failed:", e);
+    }
     setLoadingOlder(false);
   }, [history.length, historyTotal, loadingOlder]);
 
@@ -186,11 +190,13 @@ function AppShell() {
     try {
       const a = await invoke<AgentProfile[]>("get_agent_profiles");
       setAgentProfiles(a);
-    } catch {}
+    } catch (e) {
+      console.error("fetchAgentProfiles failed:", e);
+    }
   }, []);
 
   const refreshCurrentModel = () => {
-    invoke<string>("get_current_model").then(setCurrentModelName).catch(() => {});
+    invoke<string>("get_current_model").then(setCurrentModelName).catch((e) => console.error("get_current_model failed:", e));
   };
 
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve());

--- a/src/components/EngineTab.tsx
+++ b/src/components/EngineTab.tsx
@@ -29,14 +29,11 @@ function sortKeys(keys: string[]) {
   });
 }
 
+type DownloadEntry = { progress: number; speed?: number; downloaded?: number; total?: number };
 export function EngineTab({ settings, onSave, onSaveAll }: EngineTabProps) {
   const toast = useToast();
   const [localModels, setLocalModels] = useState<string[]>([]);
-  const [downloading, setDownloading] = useState<Set<string>>(new Set());
-  const [downloadProgress, setDownloadProgress] = useState<Record<string, number>>({});
-  const [downloadSpeed, setDownloadSpeed] = useState<Record<string, number>>({});
-  const [downloadedBytes, setDownloadedBytes] = useState<Record<string, number>>({});
-  const [totalBytes, setTotalBytes] = useState<Record<string, number>>({});
+  const [downloads, setDownloads] = useState<Record<string, DownloadEntry>>({});
   const [justDownloaded, setJustDownloaded] = useState<string | null>(null);
   const [modelLangFilter, setModelLangFilter] = useState("all");
   const [downloadedCollapsed, setDownloadedCollapsed] = useState(false);
@@ -58,11 +55,15 @@ export function EngineTab({ settings, onSave, onSaveAll }: EngineTabProps) {
           try {
             const has = await invoke<boolean>("has_model_assets", { modelName: k });
             if (!has) missing.add(k);
-          } catch {}
+          } catch (e) {
+            console.error("has_model_assets failed for", k, e);
+          }
         })
       );
       setMissingAssets(missing);
-    } catch {}
+    } catch (e) {
+      console.error("list_local_models failed:", e);
+    }
   }, []);
 
   const { addToast } = toast;
@@ -71,34 +72,19 @@ export function EngineTab({ settings, onSave, onSaveAll }: EngineTabProps) {
     fetchModels();
     const unlistenProgressPromise = listen<{ model: string; progress: number; speed_bps?: number; downloaded?: number; total?: number }>("download-progress", (event) => {
       const { model, progress, speed_bps, downloaded, total } = event.payload;
-      setDownloadProgress((prev) => ({ ...prev, [model]: progress }));
-      if (speed_bps !== undefined) setDownloadSpeed((prev) => ({ ...prev, [model]: speed_bps }));
-      if (downloaded !== undefined) setDownloadedBytes((prev) => ({ ...prev, [model]: downloaded }));
-      if (total !== undefined) setTotalBytes((prev) => ({ ...prev, [model]: total }));
+      setDownloads((prev) => ({
+        ...prev,
+        [model]: {
+          progress,
+          speed: speed_bps ?? prev[model]?.speed,
+          downloaded: downloaded ?? prev[model]?.downloaded,
+          total: total ?? prev[model]?.total,
+        },
+      }));
     });
     const unlistenCanceledPromise = listen<{ model: string }>("download-canceled", (event) => {
       const { model } = event.payload;
-      setDownloading((prev) => {
-        const next = new Set(prev);
-        next.delete(model);
-        return next;
-      });
-      setDownloadProgress((prev) => {
-        const next = { ...prev };
-        delete next[model];
-        return next;
-      });
-      setDownloadSpeed((prev) => {
-        const next = { ...prev };
-        delete next[model];
-        return next;
-      });
-      setDownloadedBytes((prev) => {
-        const next = { ...prev };
-        delete next[model];
-        return next;
-      });
-      setTotalBytes((prev) => {
+      setDownloads((prev) => {
         const next = { ...prev };
         delete next[model];
         return next;
@@ -112,7 +98,7 @@ export function EngineTab({ settings, onSave, onSaveAll }: EngineTabProps) {
   }, []);
 
   const downloadModel = async (name: string) => {
-    setDownloading((prev) => new Set(prev).add(name));
+    setDownloads((prev) => ({ ...prev, [name]: { progress: 0 } }));
     try {
       await invoke("download_model", { modelName: name });
       toast.addToast(`Downloaded ${name}`, "success");
@@ -126,27 +112,7 @@ export function EngineTab({ settings, onSave, onSaveAll }: EngineTabProps) {
         toast.addToast(`Failed to download ${name}`, "error");
       }
     }
-    setDownloading((prev) => {
-      const next = new Set(prev);
-      next.delete(name);
-      return next;
-    });
-    setDownloadProgress((prev) => {
-      const next = { ...prev };
-      delete next[name];
-      return next;
-    });
-    setDownloadSpeed((prev) => {
-      const next = { ...prev };
-      delete next[name];
-      return next;
-    });
-    setDownloadedBytes((prev) => {
-      const next = { ...prev };
-      delete next[name];
-      return next;
-    });
-    setTotalBytes((prev) => {
+    setDownloads((prev) => {
       const next = { ...prev };
       delete next[name];
       return next;
@@ -330,11 +296,11 @@ export function EngineTab({ settings, onSave, onSaveAll }: EngineTabProps) {
                     info={info}
                     isInstalled={false}
                     isActive={false}
-                    isDownloading={downloading.has(key)}
-                    progress={downloadProgress[key]}
-                    speedBps={downloadSpeed[key]}
-                    downloaded={downloadedBytes[key]}
-                    total={totalBytes[key]}
+                    isDownloading={key in downloads}
+                    progress={downloads[key]?.progress}
+                    speedBps={downloads[key]?.speed}
+                    downloaded={downloads[key]?.downloaded}
+                    total={downloads[key]?.total}
                     justDownloaded={justDownloaded === key}
                     onActivate={() => {}}
                     onDownload={(k) => downloadModel(k)}

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -74,7 +74,7 @@ function PasteToolControl({ value, onChange }: { value: string; onChange: (v: st
     let alive = true;
     invoke<PasteEnvironment>("get_paste_environment", { preference: value })
       .then((e) => alive && setEnv(e))
-      .catch(() => {});
+      .catch((e) => console.error("get_paste_environment failed:", e));
     return () => {
       alive = false;
     };
@@ -237,41 +237,50 @@ function SupportedKeysModal({ onClose }: { onClose: () => void }) {
   );
 }
 
-function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: number; onChange: (v: number) => void; inputDevice: string }) {
+function VadThresholdControl({ threshold, onChange, inputDevice, disabled }: { threshold: number; onChange: (v: number) => void; inputDevice: string; disabled?: boolean }) {
   const [level, setLevel] = useState(0);
-  const [levelHistory, setLevelHistory] = useState<number[]>([]);
-  const maxHistory = 30;
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const historyRef = useRef<number[]>([]);
+  const deviceRef = useRef<string>(inputDevice);
+  const wasActiveRef = useRef(false);
 
-  // Single source of truth: keep the mic preview alive while this control is
-  // mounted AND it reflects the currently-selected device. Pass the selected
-  // device explicitly so the meter updates immediately without waiting for the
-  // async settings save to propagate to the INPUT_DEVICE global. Also re-arm
-  // after recording (hotkey) which tears down the preview stream.
+  useEffect(() => {
+    deviceRef.current = inputDevice;
+  }, [inputDevice]);
+
   useEffect(() => {
     let alive = true;
     let raf = 0;
-    const deviceArg = inputDevice || null;
-    // Reset stale levels when switching devices so new mic isn't judged by old data
+    // Reset history on device switch so new mic isn't judged by old data
+    historyRef.current = [];
     setLevel(0);
-    setLevelHistory([]);
+    setPreviewError(null);
 
     const start = () => {
       if (!alive) return;
-      invoke("start_mic_preview", { device: deviceArg }).catch((e) => {
+      const d = deviceRef.current || null;
+      wasActiveRef.current = true;
+      invoke("start_mic_preview", { device: d }).catch((e) => {
         console.error("start_mic_preview failed:", e);
+        if (alive) setPreviewError(String(e));
       });
     };
 
     const loop = async () => {
       if (!alive) return;
+      // Pause polling when tab hidden to save CPU / avoid rAF churn
+      if (document.visibilityState !== "visible" || document.hidden) {
+        raf = requestAnimationFrame(loop);
+        return;
+      }
       try {
         const l = await invoke<number>("get_input_level");
         if (alive) {
+          const h = historyRef.current;
+          h.push(l);
+          if (h.length > 30) h.shift();
           setLevel(l);
-          setLevelHistory(prev => {
-            const next = [...prev, l];
-            return next.length > maxHistory ? next.slice(-maxHistory) : next;
-          });
+          if (previewError) setPreviewError(null);
         }
       } catch (e) {
         console.error("get_input_level failed:", e);
@@ -283,14 +292,18 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
     loop();
 
     // Preview is torn down during hotkey recording (start_recording clears
-    // preview_stream). Re-arm when coordinator returns to idle.
+    // preview_stream). Re-arm only if we were the active preview and we're
+    // returning to idle (avoid spurious restarts when another tab is idle).
     let unlistenState: (() => void) | null = null;
     listen<string>("wisper:state", (e) => {
       if (!alive) return;
-      if (e.payload === "idle") {
+      if (e.payload === "idle" && wasActiveRef.current) {
         setTimeout(() => {
           if (alive) start();
         }, 120);
+      }
+      if (e.payload === "recording") {
+        // Recording will clear preview; keep wasActive so idle re-arms it
       }
     })
       .then((fn) => {
@@ -301,41 +314,47 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
 
     return () => {
       alive = false;
+      wasActiveRef.current = false;
       cancelAnimationFrame(raf);
       if (unlistenState) unlistenState();
       invoke("stop_mic_preview").catch(() => {});
     };
   }, [inputDevice]);
 
-  // Compute level stats
+  // Compute level stats from ref history (no extra allocations)
   const bars = 20;
-  const peak = levelHistory.length > 0 ? Math.max(...levelHistory) : level;
-  const avg = levelHistory.length > 0
-    ? levelHistory.reduce((a, b) => a + b, 0) / levelHistory.length
-    : level;
-  const filled = Math.max(0, Math.min(bars, Math.round((avg / 0.3) * bars)));
+  const hist = historyRef.current;
+  const peak = hist.length > 0 ? Math.max(...hist) : level;
+  const avg = hist.length > 0 ? hist.reduce((a, b) => a + b, 0) / hist.length : level;
+  // Use live level for bar fill so meter feels instant; keep avg for quality/threshold
+  const filled = Math.max(0, Math.min(bars, Math.round((level / 0.3) * bars)));
   const filledIdx = Math.max(0, Math.min(bars - 1, Math.round(threshold * bars)));
-  const levelPercent = Math.round(avg * 100);
+  const levelPercent = Math.round(level * 100);
   const peakPercent = Math.round(peak * 100);
   const threshPercent = Math.round(threshold * 100);
 
-  const isAboveThreshold = avg > threshold;
+  const isAboveThreshold = level > threshold;
   const isTooLoud = peak > 0.85;
   const isClipping = peak > 0.95;
-  const isTooQuiet = levelHistory.length > 8 && avg < 0.02 && peak < 0.05;
+  const isTooQuiet = hist.length > 8 && avg < 0.02 && peak < 0.05;
   const hasSignal = peak > 0.05;
 
   let liveColor: "idle" | "quiet" | "good" | "loud" | "clipping" = "idle";
   if (isClipping) liveColor = "clipping";
   else if (isTooLoud) liveColor = "loud";
-  else if (hasSignal && isTooQuiet) liveColor = "quiet";
+  else if (isTooQuiet) liveColor = "quiet";
   else if (hasSignal) liveColor = "good";
 
   let qualityLabel: string;
   let qualityColor: string;
   let qualityBg: string;
   let recommendation: string;
-  if (isClipping) {
+  if (previewError) {
+    qualityLabel = "Mic error";
+    qualityColor = "text-recording";
+    qualityBg = "bg-recording/10";
+    recommendation = previewError;
+  } else if (isClipping) {
     qualityLabel = "Clipping";
     qualityColor = "text-recording";
     qualityBg = "bg-recording/10";
@@ -345,7 +364,7 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
     qualityColor = "text-recording";
     qualityBg = "bg-recording/10";
     recommendation = "Lower mic gain or speak softer";
-  } else if (isTooQuiet && levelHistory.length > 8) {
+  } else if (isTooQuiet) {
     qualityLabel = "Too quiet";
     qualityColor = "text-muted";
     qualityBg = "bg-elevated";
@@ -355,7 +374,7 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
     qualityColor = "text-ready";
     qualityBg = "bg-ready/10";
     recommendation = "This microphone is working well";
-  } else if (avg < 0.01 && peak < 0.02 && levelHistory.length > 0) {
+  } else if (avg < 0.01 && peak < 0.02 && hist.length > 0) {
     qualityLabel = "Listening…";
     qualityColor = "text-muted";
     qualityBg = "bg-elevated";
@@ -371,6 +390,9 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
     <div className="mt-3 space-y-3">
       {/* Live status banner - always on now that the mic is always live */}
       <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
         className={`rounded-lg ring-1 ring-stroke px-3 py-2.5 flex items-center justify-between gap-2 transition-colors duration-200 ${qualityBg}`}
       >
         <div className="flex items-center gap-2.5 min-w-0 flex-1">
@@ -394,8 +416,16 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
       </div>
 
       {/* Level meter with bar visualization */}
-      <div className="rounded-lg bg-elevated/40 ring-1 ring-stroke p-2.5 space-y-2">
-        <div className="flex items-end gap-0.5 h-10">
+      <div
+        className="rounded-lg bg-elevated/40 ring-1 ring-stroke p-2.5 space-y-2"
+        role="meter"
+        aria-label="Microphone input level"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={levelPercent}
+        aria-valuetext={`${qualityLabel} at ${levelPercent}%`}
+      >
+        <div className="flex items-end gap-0.5 h-10" aria-hidden="true">
           {[...Array(bars)].map((_, i) => {
             const isLit = i < filled;
             const isThreshBar = i === filledIdx;
@@ -441,7 +471,7 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
       </div>
 
       {/* Noise cutoff slider */}
-      <div className="flex items-center gap-2">
+      <div className={`flex items-center gap-2 ${disabled ? "opacity-50" : ""}`}>
         <label className="label-soft whitespace-nowrap">Noise cutoff</label>
         <input
           type="range"
@@ -452,9 +482,14 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
           onChange={(e) => onChange(Number(e.target.value))}
           className="flex-1 accent-accent"
           aria-label="VAD threshold"
+          disabled={disabled}
+          title={disabled ? "Enable Trim silence to adjust cutoff" : undefined}
         />
         <span className="text-xs font-mono text-muted w-10 text-right">{threshPercent}%</span>
       </div>
+      {disabled && (
+        <p className="text-[10px] font-mono text-muted/50 leading-relaxed">Enable Trim silence to make cutoff active.</p>
+      )}
     </div>
   );
 }
@@ -474,7 +509,9 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
 
   const fetchDevices = useCallback((force = false) => {
     if (!force && document.visibilityState !== "visible") return;
-    invoke<[string, string][]>("list_audio_devices").then(setInputDevices).catch(() => {});
+    invoke<[string, string][]>("list_audio_devices")
+      .then(setInputDevices)
+      .catch((e) => console.error("list_audio_devices failed:", e));
   }, []);
 
   useEffect(() => {
@@ -806,13 +843,14 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
               onChange={(v) => onSave("input_device", v)}
             />
           </div>
+          {/* Live mic meter always visible so user can pick a working mic even with VAD off */}
+          <VadThresholdControl threshold={settings.vad_threshold} onChange={(v) => onSave("vad_threshold", v)} inputDevice={settings.input_device} disabled={!settings.vad_enabled} />
           <div className="flex items-center justify-between gap-3 pt-3 border-t border-stroke">
             <span className="text-xs text-muted">Trim silence</span>
             <Switch label="Trim silence" checked={settings.vad_enabled} onChange={(v) => onSave("vad_enabled", v)} />
           </div>
-          {settings.vad_enabled && <VadThresholdControl threshold={settings.vad_threshold} onChange={(v) => onSave("vad_threshold", v)} inputDevice={settings.input_device} />}
           <p className="text-[10px] font-mono text-muted/50 leading-relaxed">
-            Defaults suit most setups. If you hear background noise or speech is clipped, adjust the sliders above and use Test microphone level.
+            Defaults suit most setups. If you hear background noise or speech is clipped, adjust the sliders above.
           </p>
         </div>
       </SectionCard>

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -239,51 +239,210 @@ function SupportedKeysModal({ onClose }: { onClose: () => void }) {
 
 function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: number; onChange: (v: number) => void; inputDevice: string }) {
   const [level, setLevel] = useState(0);
-  const [testing, setTesting] = useState(false);
+  const [levelHistory, setLevelHistory] = useState<number[]>([]);
+  const maxHistory = 30;
 
+  // Single source of truth: keep the mic preview alive while this control is
+  // mounted AND it reflects the currently-selected device. Pass the selected
+  // device explicitly so the meter updates immediately without waiting for the
+  // async settings save to propagate to the INPUT_DEVICE global. Also re-arm
+  // after recording (hotkey) which tears down the preview stream.
   useEffect(() => {
-    if (!testing) return;
     let alive = true;
     let raf = 0;
-    invoke("start_mic_preview").catch(() => {});
-    async function loop() {
+    const deviceArg = inputDevice || null;
+    // Reset stale levels when switching devices so new mic isn't judged by old data
+    setLevel(0);
+    setLevelHistory([]);
+
+    const start = () => {
+      if (!alive) return;
+      invoke("start_mic_preview", { device: deviceArg }).catch((e) => {
+        console.error("start_mic_preview failed:", e);
+      });
+    };
+
+    const loop = async () => {
+      if (!alive) return;
       try {
         const l = await invoke<number>("get_input_level");
-        if (alive) setLevel(l);
-      } catch {}
+        if (alive) {
+          setLevel(l);
+          setLevelHistory(prev => {
+            const next = [...prev, l];
+            return next.length > maxHistory ? next.slice(-maxHistory) : next;
+          });
+        }
+      } catch (e) {
+        console.error("get_input_level failed:", e);
+      }
       if (alive) raf = requestAnimationFrame(loop);
-    }
+    };
+
+    start();
     loop();
+
+    // Preview is torn down during hotkey recording (start_recording clears
+    // preview_stream). Re-arm when coordinator returns to idle.
+    let unlistenState: (() => void) | null = null;
+    listen<string>("wisper:state", (e) => {
+      if (!alive) return;
+      if (e.payload === "idle") {
+        setTimeout(() => {
+          if (alive) start();
+        }, 120);
+      }
+    })
+      .then((fn) => {
+        if (alive) unlistenState = fn;
+        else fn();
+      })
+      .catch(() => {});
+
     return () => {
       alive = false;
       cancelAnimationFrame(raf);
+      if (unlistenState) unlistenState();
       invoke("stop_mic_preview").catch(() => {});
     };
-  }, [testing, inputDevice]);
+  }, [inputDevice]);
 
-  useEffect(() => {
-    if (!testing) return;
-    invoke("stop_mic_preview").catch(() => {});
-    invoke("start_mic_preview").catch(() => {});
-  }, [inputDevice, testing]);
+  // Compute level stats
+  const bars = 20;
+  const peak = levelHistory.length > 0 ? Math.max(...levelHistory) : level;
+  const avg = levelHistory.length > 0
+    ? levelHistory.reduce((a, b) => a + b, 0) / levelHistory.length
+    : level;
+  const filled = Math.max(0, Math.min(bars, Math.round((avg / 0.3) * bars)));
+  const filledIdx = Math.max(0, Math.min(bars - 1, Math.round(threshold * bars)));
+  const levelPercent = Math.round(avg * 100);
+  const peakPercent = Math.round(peak * 100);
+  const threshPercent = Math.round(threshold * 100);
 
-  const startToggle = () => {
-    if (testing) {
-      setTesting(false);
-    } else {
-      setLevel(0);
-      setTesting(true);
-    }
-  };
+  const isAboveThreshold = avg > threshold;
+  const isTooLoud = peak > 0.85;
+  const isClipping = peak > 0.95;
+  const isTooQuiet = levelHistory.length > 8 && avg < 0.02 && peak < 0.05;
+  const hasSignal = peak > 0.05;
 
-  const barCount = 10;
-  const filled = Math.max(0, Math.round((level / 0.3) * barCount));
-  const threshIdx = Math.max(0, Math.min(barCount - 1, Math.round(threshold * barCount)));
+  let liveColor: "idle" | "quiet" | "good" | "loud" | "clipping" = "idle";
+  if (isClipping) liveColor = "clipping";
+  else if (isTooLoud) liveColor = "loud";
+  else if (hasSignal && isTooQuiet) liveColor = "quiet";
+  else if (hasSignal) liveColor = "good";
+
+  let qualityLabel: string;
+  let qualityColor: string;
+  let qualityBg: string;
+  let recommendation: string;
+  if (isClipping) {
+    qualityLabel = "Clipping";
+    qualityColor = "text-recording";
+    qualityBg = "bg-recording/10";
+    recommendation = "Reduce input volume or move away from mic";
+  } else if (isTooLoud) {
+    qualityLabel = "Too loud";
+    qualityColor = "text-recording";
+    qualityBg = "bg-recording/10";
+    recommendation = "Lower mic gain or speak softer";
+  } else if (isTooQuiet && levelHistory.length > 8) {
+    qualityLabel = "Too quiet";
+    qualityColor = "text-muted";
+    qualityBg = "bg-elevated";
+    recommendation = "Increase mic gain or move closer to mic";
+  } else if (hasSignal) {
+    qualityLabel = "Good";
+    qualityColor = "text-ready";
+    qualityBg = "bg-ready/10";
+    recommendation = "This microphone is working well";
+  } else if (avg < 0.01 && peak < 0.02 && levelHistory.length > 0) {
+    qualityLabel = "Listening…";
+    qualityColor = "text-muted";
+    qualityBg = "bg-elevated";
+    recommendation = "";
+  } else {
+    qualityLabel = "Speak to test";
+    qualityColor = "text-muted";
+    qualityBg = "bg-elevated";
+    recommendation = "";
+  }
 
   return (
-    <div className="mt-3 space-y-2">
+    <div className="mt-3 space-y-3">
+      {/* Live status banner - always on now that the mic is always live */}
+      <div
+        className={`rounded-lg ring-1 ring-stroke px-3 py-2.5 flex items-center justify-between gap-2 transition-colors duration-200 ${qualityBg}`}
+      >
+        <div className="flex items-center gap-2.5 min-w-0 flex-1">
+          <span
+            className={`w-2 h-2 rounded-full ${
+              liveColor === "clipping" || liveColor === "loud"
+                ? "bg-recording"
+                : liveColor === "good"
+                ? "bg-ready"
+                : "bg-muted"
+            } ${hasSignal ? "animate-pulse" : ""}`}
+            aria-hidden
+          />
+          <span className={`text-sm font-semibold ${qualityColor}`}>{qualityLabel}</span>
+        </div>
+        {recommendation && (
+          <span className="text-[10px] font-mono text-muted/80 text-right truncate max-w-[60%]">
+            {recommendation}
+          </span>
+        )}
+      </div>
+
+      {/* Level meter with bar visualization */}
+      <div className="rounded-lg bg-elevated/40 ring-1 ring-stroke p-2.5 space-y-2">
+        <div className="flex items-end gap-0.5 h-10">
+          {[...Array(bars)].map((_, i) => {
+            const isLit = i < filled;
+            const isThreshBar = i === filledIdx;
+            let cls = "bg-elevated";
+            if (isLit) {
+              // Color based on level: green (good) → yellow (loud) → red (clipping)
+              if (liveColor === "clipping" || i >= bars * 0.85) cls = "bg-recording";
+              else if (liveColor === "loud" || i >= bars * 0.7) cls = "bg-yellow-500";
+              else cls = "bg-ready";
+            } else if (isThreshBar) {
+              cls = "bg-accent/60";
+            }
+            return (
+              <div
+                key={i}
+                className={`flex-1 rounded-sm transition-colors duration-75 ${cls}`}
+                style={{ height: `${20 + (i * 2)}%` }}
+              />
+            );
+          })}
+        </div>
+
+        {/* Numeric feedback row */}
+        <div className="flex items-center justify-between text-[10px] font-mono text-muted/70">
+          <span title="Average loudness right now">
+            Level: <span className="text-ink">{levelPercent}%</span>
+          </span>
+          <span title="Loudest moment in the recent window">
+            Peak: <span className="text-ink">{peakPercent}%</span>
+          </span>
+          <span title="Noise cutoff threshold">
+            Cutoff: <span className="text-ink">{threshPercent}%</span>
+          </span>
+        </div>
+
+        {/* Status row: threshold */}
+        <div className="flex items-center justify-between gap-2 pt-1.5 border-t border-stroke/50">
+          <span className={`text-[10px] font-mono ${isAboveThreshold ? "text-ready" : "text-muted"}`}>
+            {isAboveThreshold ? "✓ Above cutoff" : "○ Below cutoff"}
+          </span>
+          <span className="text-[10px] font-mono text-muted/80 text-right">Speak — bars should hit green, not red</span>
+        </div>
+      </div>
+
+      {/* Noise cutoff slider */}
       <div className="flex items-center gap-2">
-        <label className="label-soft">Noise cutoff</label>
+        <label className="label-soft whitespace-nowrap">Noise cutoff</label>
         <input
           type="range"
           min="0"
@@ -294,34 +453,8 @@ function VadThresholdControl({ threshold, onChange, inputDevice }: { threshold: 
           className="flex-1 accent-accent"
           aria-label="VAD threshold"
         />
-        <span className="text-xs font-mono text-muted w-10 text-right">{Math.round(threshold * 100)}%</span>
+        <span className="text-xs font-mono text-muted w-10 text-right">{threshPercent}%</span>
       </div>
-      <div className="flex items-end gap-1 h-6">
-        {[...Array(barCount)].map((_, i) => {
-          const aboveThresh = i >= threshIdx;
-          const active = i < filled && aboveThresh;
-          const cls = active
-            ? "bg-accent"
-            : i === threshIdx
-            ? "bg-accent/50"
-            : aboveThresh
-            ? "bg-elevated"
-            : "bg-elevated/40";
-          return (
-            <div
-              key={i}
-              className={`flex-1 rounded transition-colors ${cls}`}
-              style={{ height: `${Math.max(4, (i + 1) * 3)}px` }}
-            />
-          );
-        })}
-      </div>
-      <button
-        onClick={startToggle}
-        className="text-xs font-mono text-muted hover:text-ink transition-colors"
-      >
-        {testing ? "Stop testing" : "Test microphone level"}
-      </button>
     </div>
   );
 }
@@ -482,23 +615,6 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
           )}
 
           <div className="grid gap-3 grid-cols-1">
-            <div>
-              <div className="flex items-center justify-between gap-2 mb-1.5">
-                <label className="label-soft">Microphone</label>
-                <button type="button" onClick={() => fetchDevices(true)} className="text-[10px] font-mono text-accent hover:text-accent-dim">Refresh</button>
-              </div>
-              <Select
-                value={settings.input_device}
-                options={(() => {
-                  const opts: { value: string; label: string }[] = [{ value: "", label: "System default" }, ...inputDevices.map(([id, name]) => ({ value: id, label: name }))];
-                  if (settings.input_device && !opts.some((o) => o.value === settings.input_device)) {
-                    opts.push({ value: settings.input_device, label: `${settings.input_device} - not found` });
-                  }
-                  return opts;
-                })()}
-                onChange={(v) => onSave("input_device", v)}
-              />
-            </div>
             <div>
               <label className="label-soft block mb-1.5">Transcription languages</label>
               <div className="rounded-lg bg-elevated/40 ring-1 ring-stroke p-2.5">
@@ -673,6 +789,23 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
               <span className="text-xs font-mono text-muted w-8 text-right">{Math.round(settings.noise_suppression_level * 100)}%</span>
             </div>
           )}
+          <div>
+            <div className="flex items-center justify-between gap-2 mb-1.5">
+              <label className="label-soft">Microphone</label>
+              <button type="button" onClick={() => fetchDevices(true)} className="text-[10px] font-mono text-accent hover:text-accent-dim">Refresh</button>
+            </div>
+            <Select
+              value={settings.input_device}
+              options={(() => {
+                const opts: { value: string; label: string }[] = [{ value: "", label: "System default" }, ...inputDevices.map(([id, name]) => ({ value: id, label: name }))];
+                if (settings.input_device && !opts.some((o) => o.value === settings.input_device)) {
+                  opts.push({ value: settings.input_device, label: `${settings.input_device} - not found` });
+                }
+                return opts;
+              })()}
+              onChange={(v) => onSave("input_device", v)}
+            />
+          </div>
           <div className="flex items-center justify-between gap-3 pt-3 border-t border-stroke">
             <span className="text-xs text-muted">Trim silence</span>
             <Switch label="Trim silence" checked={settings.vad_enabled} onChange={(v) => onSave("vad_enabled", v)} />


### PR DESCRIPTION
## Summary
Makes microphone testing instant and reliable. Preview is now always-live (no Test button), shows Level/Peak/Cutoff, live color states and guidance, and fixes the stale-device silent-meter bug.

Fixes all 12 audit findings.

## Backend
- **audio: harden device switching** (`audio.rs:304`) — `start_preview` now resolves device first, stores resolved `cpal` id in `preview_device`, idempotent when same mic, tears down only on different mic. Handles `hw`/`plughw`/`dsnoop` aliases.
- **audio: compare resolved id** — avoids unnecessary teardown when same physical mic is requested via different alias.
- **audio: avoid flicker** — `start_recording` no longer `level.store(0)`; keeps last RMS until recording callback updates.
- **lib: explicit device param** (`lib.rs:125`) — `start_mic_preview(device: Option<String>)` now takes frontend-selected device directly, falling back to `INPUT_DEVICE` global only when `None` — fixes race where settings save hadn't propagated.

## Frontend — GeneralTab
- **Always-live meter** — `VadThresholdControl` (`GeneralTab.tsx:839`) no longer gated behind `vad_enabled`; threshold slider disabled with hint when VAD off. Microphone selector stays in Audio Processing below noise suppression.
- **Stale closure** — `deviceRef` (`GeneralTab.tsx:254`) ensures idle re-arm uses latest selected mic, not closed-over old value.
- **Dead branch** — `liveColor` `hasSignal && isTooQuiet` (impossible `peak>0.05 && peak<0.05`) → `isTooQuiet`.
- **Responsiveness** — bars and `isAboveThreshold` now use live `level` not smoothed `avg`; 20 bars, green→yellow→red by `liveColor`.
- **Idle guard** — `wasActiveRef` (`GeneralTab.tsx:287`) only re-arms on `wisper:state:idle` if preview was active.
- **Visibility** — rAF loop skips when `document.hidden`.
- **Allocations** — `levelHistory` state → `historyRef` push/shift (no 60 allocs/sec).
- **a11y** — `role="meter"`/`status` `aria-live`, `aria-valuenow/text` on meter.
- **Errors surfaced** — `previewError` banner, `fetchDevices`/`get_paste_environment` now log instead of silent `catch(()=>{})`.

## Frontend — Engine/App
- **Engine: consolidate downloads** (`EngineTab.tsx:32`) — 5 `useState` → single `downloads: Record<string,DownloadEntry>`; atomic single `setState` per progress event.
- **App: silent catches** — `fetchHistory`/`loadOlder`/`fetchAgentProfiles`/`get_current_model` now `console.error`.

## Verification
`pnpm build` ✅ `cargo check` ✅
Tested: System default and named mics both show live levels; VAD on/off; hotkey recording re-arms preview after idle.