### PR TITLE
feat(window): Ctrl+W hides window, Ctrl+Q quits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Wisper is a lightweight, privacy-first desktop dictation app for Linux. Press a 
 - **Cleans up as it goes** - optional AI step reformats and polishes the transcript (6 Writing Styles: Auto, Clean-up, Email, Developer, Messaging, Formal + Custom; 6 providers: OpenAI, Anthropic, Groq, OpenRouter, Ollama, OpenCode Go + Custom with endpoint-aware `/chat/completions` `/responses` `/messages` and Test connection), compact deduplicated output with typo/filler fixes, plus silence trimming.
 - **Your words, your way** - custom vocabulary turns shortcuts into proper terms (say "gpt", get "GPT").
 - **Look back** - searchable history lets you replay the recording, re-transcribe, or edit any past dictation, and shows how much typing time you've saved.
-- **Out of the way** - lives in the system tray; close the window and it keeps running, ready for the next hotkey.
+- **Out of the way** - lives in the system tray; close the window and it keeps running, ready for the next hotkey. `Ctrl+W` hides the window (tray stays), `Ctrl+Q` quits entirely.
 - **Updates itself** - checks GitHub releases and installs new versions in-app.
 
 ## How it works

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,6 +154,19 @@ fn list_audio_devices() -> Vec<(String, String)> {
 }
 
 #[tauri::command]
+fn hide_main_window(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(win) = app.get_webview_window("main") {
+        win.hide().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+fn quit_app(app: tauri::AppHandle) {
+    app.exit(0);
+}
+
+#[tauri::command]
 fn stop_mic_preview() {
     if let Some(r) = RECORDER.lock().unwrap_or_else(|e| e.into_inner()).as_ref() {
         r.stop_preview();
@@ -844,7 +857,9 @@ pub fn run() {
             settings::get_default_settings,
             start_mic_preview,
             stop_mic_preview,
-            list_audio_devices
+            list_audio_devices,
+            hide_main_window,
+            quit_app
         ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,26 @@ function AppShell() {
     safeStorageSet(storageKey("active-tab"), activeTab);
   }, [activeTab]);
 
+  // Global window shortcuts: Ctrl+W hides window (keeps tray), Ctrl+Q quits entirely
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const isCtrl = e.ctrlKey || e.metaKey;
+      if (!isCtrl) return;
+      const key = e.key.toLowerCase();
+      if (key === "q") {
+        e.preventDefault();
+        e.stopPropagation();
+        invoke("quit_app").catch((err) => console.error("quit_app failed:", err));
+      } else if (key === "w") {
+        e.preventDefault();
+        e.stopPropagation();
+        invoke("hide_main_window").catch((err) => console.error("hide_main_window failed:", err));
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   useEffect(() => {
     let alive = true;
     invoke<AppSettings>("load_settings").then((v) => alive && setSettings(v)).catch((e) => { console.error(e); });

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -877,6 +877,9 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
           <span className="text-xs text-muted">Launch to system tray</span>
           <Switch label="Launch to system tray" checked={settings.launch_to_tray} onChange={(v) => onSave("launch_to_tray", v)} />
         </div>
+        <p className="text-[10px] font-mono text-muted/50 leading-relaxed mt-2">
+          Tip: <span className="text-ink">Ctrl+W</span> hides window (tray stays) · <span className="text-ink">Ctrl+Q</span> quits entirely.
+        </p>
       </SectionCard>
 
       <SectionCard title="History">


### PR DESCRIPTION
## Summary
Adds keyboard window controls: **Ctrl+W** hides the main window (tray stays, mirrors X-button hide: `on_window_event` `hide() + prevent_close()`), **Ctrl+Q** quits entirely (tray removed, `app.exit(0)` like tray Quit).

## Changes
- **Backend** `src-tauri/src/lib.rs:156` — new commands `hide_main_window` and `quit_app`, registered in `invoke_handler`.
- **Frontend** `src/App.tsx:84` — global `keydown` listener (Ctrl/Meta + W/Q, `preventDefault` + `stopPropagation`) invoking the commands when window focused.
- **Docs/UI** `src/components/GeneralTab.tsx:880` — tip in **Startup** below "Launch to system tray": `Ctrl+W hides window (tray stays) · Ctrl+Q quits entirely.`  `README.md:15` Features bullet updated.

## Verification
`pnpm build` ✅ `cargo check` ✅
Manual: focused Wisper window, Ctrl+W hides (tray stays, click to reopen), Ctrl+Q exits (tray gone).