### PR TITLE
feat(dictionary): profile-aware dictionary with sharing and updates

### DIFF
--- a/src-tauri/resources/profiles/developer.json
+++ b/src-tauri/resources/profiles/developer.json
@@ -1,0 +1,2085 @@
+{
+  "id": "wisper-developer-v1",
+  "name": "Developer",
+  "description": "Programming languages, frameworks, tools and CLI commands \u2014 toggle on only while you code",
+  "version": "2026-09-03",
+  "author": "Wisper",
+  "update_url": "",
+  "entries": [
+    {
+      "phrase": "TypeScript",
+      "variants": [
+        "type script",
+        "type-script"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "JavaScript",
+      "variants": [
+        "java script",
+        "java-script"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Python",
+      "variants": [
+        "pie thon"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Go",
+      "variants": [
+        "go lang",
+        "go language"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Rust",
+      "variants": [
+        "rust"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Ruby",
+      "variants": [
+        "ruby"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Swift",
+      "variants": [
+        "swift"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Kotlin",
+      "variants": [
+        "cot lin"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Dart",
+      "variants": [
+        "dart"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "PHP",
+      "variants": [
+        "p h p"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Perl",
+      "variants": [
+        "pearl"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Lua",
+      "variants": [
+        "loo ah"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Zig",
+      "variants": [
+        "zig"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Elixir",
+      "variants": [
+        "elixir"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Erlang",
+      "variants": [
+        "er lang"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Haskell",
+      "variants": [
+        "haskell"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Scala",
+      "variants": [
+        "scarla"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Clojure",
+      "variants": [
+        "closure"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Julia",
+      "variants": [
+        "julia"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "R",
+      "variants": [
+        "r lang",
+        "r language"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "C#",
+      "variants": [
+        "c sharp",
+        "c hashtag"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "C++",
+      "variants": [
+        "c plus plus",
+        "cplusplus"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": ".NET",
+      "variants": [
+        "dot net",
+        "dotnet"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "Objective-C",
+      "variants": [
+        "objective c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "Solidity",
+      "variants": [
+        "solidity"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "WebAssembly",
+      "variants": [
+        "web assembly",
+        "wasm"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Bash",
+      "variants": [
+        "bash"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "PostgreSQL",
+      "variants": [
+        "post gres",
+        "postgress",
+        "postgres"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "MySQL",
+      "variants": [
+        "my sequel",
+        "my sql",
+        "my s q l"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "SQLite",
+      "variants": [
+        "sequel lite",
+        "s q lite",
+        "sql lite"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Redis",
+      "variants": [
+        "read is",
+        "red is"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "MongoDB",
+      "variants": [
+        "mongo d b",
+        "mongo db"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Cassandra",
+      "variants": [
+        "cassandra"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "DynamoDB",
+      "variants": [
+        "dynamo d b"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Elasticsearch",
+      "variants": [
+        "elastic search"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ClickHouse",
+      "variants": [
+        "click house"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Snowflake",
+      "variants": [
+        "snow flake"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "BigQuery",
+      "variants": [
+        "big query"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Firestore",
+      "variants": [
+        "fire store"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Supabase",
+      "variants": [
+        "super base",
+        "soopa base"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Firebase",
+      "variants": [
+        "fire base"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Prisma",
+      "variants": [
+        "prizma"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Drizzle",
+      "variants": [
+        "drizzle"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Neon",
+      "variants": [
+        "neon db"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "PlanetScale",
+      "variants": [
+        "planet scale"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CockroachDB",
+      "variants": [
+        "cockroach d b"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Kubernetes",
+      "variants": [
+        "kuber netties",
+        "cuber netties",
+        "k8s",
+        "koobernetes",
+        "kubernates",
+        "kube netes"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "kubectl",
+      "variants": [
+        "cube ctl",
+        "cube control",
+        "kubecuttle",
+        "kubectrl",
+        "kube control"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Docker",
+      "variants": [
+        "doker"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Dockerfile",
+      "variants": [
+        "docker file"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Helm",
+      "variants": [
+        "helm"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Terraform",
+      "variants": [
+        "terra form"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Ansible",
+      "variants": [
+        "ansible"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Jenkins",
+      "variants": [
+        "jenkins"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CircleCI",
+      "variants": [
+        "circle c i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GitHub Actions",
+      "variants": [
+        "git hub actions"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GitLab CI",
+      "variants": [
+        "git lab c i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ArgoCD",
+      "variants": [
+        "argo c d"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Flux",
+      "variants": [
+        "flux cd"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Prometheus",
+      "variants": [
+        "prometheus"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Grafana",
+      "variants": [
+        "grafana"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Nginx",
+      "variants": [
+        "engine x",
+        "en jinx"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Traefik",
+      "variants": [
+        "traffic"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Vercel",
+      "variants": [
+        "ver cell"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Cloudflare",
+      "variants": [
+        "cloud flare",
+        "cloud flair"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Netlify",
+      "variants": [
+        "netlify"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Heroku",
+      "variants": [
+        "heroku"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "DigitalOcean",
+      "variants": [
+        "digital ocean"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Linode",
+      "variants": [
+        "lin ode"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Hetzner",
+      "variants": [
+        "hetzner"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Cloud Run",
+      "variants": [
+        "cloud run"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Lambda",
+      "variants": [
+        "lambda"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "S3",
+      "variants": [
+        "s 3",
+        "ess three"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "EC2",
+      "variants": [
+        "e c 2"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "EKS",
+      "variants": [
+        "e k s"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GKE",
+      "variants": [
+        "g k e"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "React",
+      "variants": [
+        "re act"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Next.js",
+      "variants": [
+        "next j s",
+        "next g s",
+        "next js"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "Vue",
+      "variants": [
+        "view"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Nuxt",
+      "variants": [
+        "nuxed"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Svelte",
+      "variants": [
+        "svelte"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Astro",
+      "variants": [
+        "astro"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Remix",
+      "variants": [
+        "remix"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Angular",
+      "variants": [
+        "angular"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "SolidJS",
+      "variants": [
+        "solid j s"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Qwik",
+      "variants": [
+        "quick"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Tailwind",
+      "variants": [
+        "tail wind"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Bootstrap",
+      "variants": [
+        "bootstrap"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "MUI",
+      "variants": [
+        "m u i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Chakra UI",
+      "variants": [
+        "chakra u i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "shadcn",
+      "variants": [
+        "shad c n"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Vite",
+      "variants": [
+        "veet"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Webpack",
+      "variants": [
+        "web pack"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "esbuild",
+      "variants": [
+        "e s build"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Turbopack",
+      "variants": [
+        "turbo pack"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Rollup",
+      "variants": [
+        "roll up"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Babel",
+      "variants": [
+        "babel"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Biome",
+      "variants": [
+        "biome"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ESLint",
+      "variants": [
+        "e s lint"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Prettier",
+      "variants": [
+        "prettier"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Node.js",
+      "variants": [
+        "node j s",
+        "node js"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "Deno",
+      "variants": [
+        "deno"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Bun",
+      "variants": [
+        "bun"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Tauri",
+      "variants": [
+        "taw ree",
+        "tory"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Electron",
+      "variants": [
+        "electron"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "FastAPI",
+      "variants": [
+        "fast a p i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Django",
+      "variants": [
+        "django"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Flask",
+      "variants": [
+        "flask"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Spring Boot",
+      "variants": [
+        "spring boot"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Laravel",
+      "variants": [
+        "laravel"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Ruby on Rails",
+      "variants": [
+        "ruby on rails"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Phoenix",
+      "variants": [
+        "phoenix"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Actix",
+      "variants": [
+        "act x"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Axum",
+      "variants": [
+        "ax um"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Tokio",
+      "variants": [
+        "tokio"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "gRPC",
+      "variants": [
+        "g r p c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "tRPC",
+      "variants": [
+        "t r p c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "REST",
+      "variants": [
+        "rest"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "REST API",
+      "variants": [
+        "r e s t a p i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GraphQL",
+      "variants": [
+        "graph q l",
+        "graph ql"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "WebSocket",
+      "variants": [
+        "web socket"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "WebRTC",
+      "variants": [
+        "web r t c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "pnpm",
+      "variants": [
+        "p n p m"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "npm",
+      "variants": [
+        "n p m",
+        "en pee em"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "yarn",
+      "variants": [
+        "yawn"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Homebrew",
+      "variants": [
+        "home brew"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "brew",
+      "variants": [
+        "brews"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "cargo",
+      "variants": [
+        "cargos"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "pip",
+      "variants": [
+        "pips"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "poetry",
+      "variants": [
+        "poetrys"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "uv",
+      "variants": [
+        "u v"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Make",
+      "variants": [
+        "make file"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Makefile",
+      "variants": [
+        "make file"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CMake",
+      "variants": [
+        "c make"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Gradle",
+      "variants": [
+        "gradle"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Maven",
+      "variants": [
+        "maven"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "sudo",
+      "variants": [
+        "pseudo",
+        "sue doe",
+        "sue do"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "chmod",
+      "variants": [
+        "c mod",
+        "che mod",
+        "change mod"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "chown",
+      "variants": [
+        "c h own",
+        "ch own"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "grep",
+      "variants": [
+        "grip"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "curl",
+      "variants": [
+        "cur l",
+        "kurl",
+        "kerl"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "wget",
+      "variants": [
+        "w get"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "jq",
+      "variants": [
+        "j q"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "yq",
+      "variants": [
+        "y q"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "sed",
+      "variants": [
+        "said"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "awk",
+      "variants": [
+        "awks"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "systemd",
+      "variants": [
+        "system d"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "journalctl",
+      "variants": [
+        "journal c t l"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "JSON",
+      "variants": [
+        "jason"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "YAML",
+      "variants": [
+        "yam el",
+        "yah mel",
+        "yammal"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TOML",
+      "variants": [
+        "tom el"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Markdown",
+      "variants": [
+        "mark down"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CSV",
+      "variants": [
+        "c s v"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Parquet",
+      "variants": [
+        "parquet"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Protobuf",
+      "variants": [
+        "proto buff"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Avro",
+      "variants": [
+        "avro"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "API",
+      "variants": [
+        "a p i",
+        "a pie"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": ".env",
+      "variants": [
+        "dot env",
+        "dot e n v"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "HTTP",
+      "variants": [
+        "h t t p"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "HTTPS",
+      "variants": [
+        "h t t p s"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "SSL",
+      "variants": [
+        "s s l"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TLS",
+      "variants": [
+        "t l s"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "SSH",
+      "variants": [
+        "s s h",
+        "ess ess aych"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TCP",
+      "variants": [
+        "t c p"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "UDP",
+      "variants": [
+        "u d p"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "DNS",
+      "variants": [
+        "d n s"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CDN",
+      "variants": [
+        "c d n"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CI/CD",
+      "variants": [
+        "c i slash c d",
+        "c i c d",
+        "c i / c d"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "OAuth",
+      "variants": [
+        "o auth",
+        "o off"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "JWT",
+      "variants": [
+        "j w t",
+        "jot"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "SAML",
+      "variants": [
+        "saml"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "OIDC",
+      "variants": [
+        "o i d c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CORS",
+      "variants": [
+        "course",
+        "c o r s"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GitHub",
+      "variants": [
+        "git hub"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GitLab",
+      "variants": [
+        "git lab"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Bitbucket",
+      "variants": [
+        "bit bucket"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Jira",
+      "variants": [
+        "jira"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Confluence",
+      "variants": [
+        "confluence"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Linear",
+      "variants": [
+        "linear"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Notion",
+      "variants": [
+        "notion"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Slack",
+      "variants": [
+        "slack"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Figma",
+      "variants": [
+        "figma"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Stripe",
+      "variants": [
+        "stripe"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "OpenAI",
+      "variants": [
+        "open a i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Anthropic",
+      "variants": [
+        "anthropic"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Hugging Face",
+      "variants": [
+        "hugging face"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "LangChain",
+      "variants": [
+        "lang chain"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Pinecone",
+      "variants": [
+        "pine cone"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Weaviate",
+      "variants": [
+        "weaviate"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Qdrant",
+      "variants": [
+        "qdrant"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Meilisearch",
+      "variants": [
+        "meili search"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Algolia",
+      "variants": [
+        "algolia"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "LLM",
+      "variants": [
+        "l l m"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "RAG",
+      "variants": [
+        "r a g"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Vector DB",
+      "variants": [
+        "vector d b"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Embedding",
+      "variants": [
+        "embedding"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "PyTorch",
+      "variants": [
+        "pie torch"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TensorFlow",
+      "variants": [
+        "tensor flow"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Keras",
+      "variants": [
+        "keras"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "NumPy",
+      "variants": [
+        "num pie"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Pandas",
+      "variants": [
+        "pandas"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Polars",
+      "variants": [
+        "polars"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Jupyter",
+      "variants": [
+        "jupyter"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CUDA",
+      "variants": [
+        "c u d a"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ROCm",
+      "variants": [
+        "rock em"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "localhost",
+      "variants": [
+        "local host"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "middleware",
+      "variants": [
+        "middle ware"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "microservice",
+      "variants": [
+        "micro service"
+      ],
+      "caseSensitive": false,
+      "wholeWord": false
+    },
+    {
+      "phrase": "monorepo",
+      "variants": [
+        "mono repo"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "monolith",
+      "variants": [
+        "mono lith"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "polyrepo",
+      "variants": [
+        "poly repo"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "pull request",
+      "variants": [
+        "pool request"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "merge conflict",
+      "variants": [
+        "merge conflicts"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "rebase",
+      "variants": [
+        "re base"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "cherry-pick",
+      "variants": [
+        "cherry pick"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "deadlock",
+      "variants": [
+        "dead lock"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "race condition",
+      "variants": [
+        "race conditions"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "idempotent",
+      "variants": [
+        "idempotents"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "eventual consistency",
+      "variants": [
+        "eventual consistencys"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "sharding",
+      "variants": [
+        "shardings"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "replication",
+      "variants": [
+        "replications"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "pubsub",
+      "variants": [
+        "pub sub"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Queue",
+      "variants": [],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Auth",
+      "variants": [
+        "orth"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "compilation",
+      "variants": [
+        "compilations"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "transpilation",
+      "variants": [
+        "transpilations"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "bundling",
+      "variants": [
+        "bundlings"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "tree-shaking",
+      "variants": [
+        "tree shaking"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "hot reload",
+      "variants": [
+        "hot reloads"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "SSR",
+      "variants": [
+        "s s r"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CSR",
+      "variants": [
+        "c s r"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "SSG",
+      "variants": [
+        "s s g"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ISR",
+      "variants": [
+        "i s r"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Edge Function",
+      "variants": [
+        "edge function"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Serverless",
+      "variants": [
+        "server less"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Container",
+      "variants": [
+        "container"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Orchestration",
+      "variants": [
+        "orchestration"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Observability",
+      "variants": [
+        "observability"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Telemetry",
+      "variants": [
+        "telemetry"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Stack trace",
+      "variants": [
+        "stack trace"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Heap",
+      "variants": [
+        "heap"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Garbage collection",
+      "variants": [
+        "garbage collection"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Async",
+      "variants": [
+        "async"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "async/await",
+      "variants": [
+        "async await",
+        "asynch await"
+      ],
+      "caseSensitive": false,
+      "wholeWord": false
+    },
+    {
+      "phrase": "Concurrency",
+      "variants": [
+        "concurrency"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Parallelism",
+      "variants": [
+        "parallelism"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Mutex",
+      "variants": [
+        "mutex"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Semaphore",
+      "variants": [
+        "semaphore"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Debounce",
+      "variants": [
+        "debounce"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Throttle",
+      "variants": [
+        "throttle"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Memoization",
+      "variants": [
+        "memoization"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Virtualization",
+      "variants": [
+        "virtualization"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Containerization",
+      "variants": [
+        "containerization"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    }
+  ]
+}

--- a/src-tauri/resources/profiles/email.json
+++ b/src-tauri/resources/profiles/email.json
@@ -1,0 +1,556 @@
+{
+  "id": "wisper-email-v1",
+  "name": "Email",
+  "description": "Common email greetings, closings and polite business phrases",
+  "version": "2026-09-03",
+  "author": "Wisper",
+  "update_url": "",
+  "entries": [
+    {
+      "phrase": "Best regards",
+      "variants": [
+        "best regard"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Kind regards",
+      "variants": [
+        "kind regard"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Warm regards",
+      "variants": [
+        "warm regard"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Sincerely",
+      "variants": [
+        "sincerely",
+        "sincerly"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Yours sincerely",
+      "variants": [
+        "yours sincerely"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Yours faithfully",
+      "variants": [
+        "yours faithfully"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Many thanks",
+      "variants": [
+        "many thanks"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Thank you for your time",
+      "variants": [
+        "thanks for your time"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Thanks in advance",
+      "variants": [
+        "thanks in advance"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Looking forward to hearing from you",
+      "variants": [
+        "looking forward to hearing from you"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Looking forward to your reply",
+      "variants": [
+        "looking forward to your reply"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Please find attached",
+      "variants": [
+        "please find attached"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Attached please find",
+      "variants": [
+        "attached please find"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "As discussed",
+      "variants": [
+        "as discussed"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "As per our conversation",
+      "variants": [
+        "as per conversation"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Following up on",
+      "variants": [
+        "following up on"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Just following up",
+      "variants": [
+        "just following up"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Let me know if you have any questions",
+      "variants": [
+        "let me know if you have questions"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Feel free to reach out",
+      "variants": [
+        "feel free to reach out"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Hope you're well",
+      "variants": [
+        "hope your well",
+        "hope you are well"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Hope you're doing well",
+      "variants": [
+        "hope you are doing well"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Hope this email finds you well",
+      "variants": [
+        "hope this email finds you well"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Sorry for the delayed response",
+      "variants": [
+        "sorry for the late response",
+        "sorry for delayed response"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Apologies for the delay",
+      "variants": [
+        "apologies for the delay"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Thank you for your patience",
+      "variants": [
+        "thanks for your patience"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Thank you for reaching out",
+      "variants": [
+        "thanks for reaching out"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "I would like to follow up",
+      "variants": [
+        "i would like to follow up"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Per my last email",
+      "variants": [
+        "per last email"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Looping in",
+      "variants": [
+        "looping in"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "CC'ing",
+      "variants": [
+        "cc ing",
+        "ccing"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "BCC",
+      "variants": [
+        "b c c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "FYI",
+      "variants": [
+        "f y i",
+        "for your information"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "EOD",
+      "variants": [
+        "e o d",
+        "end of day"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "COB",
+      "variants": [
+        "c o b",
+        "close of business"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ASAP",
+      "variants": [
+        "a sap",
+        "a s a p"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "RSVP",
+      "variants": [
+        "r s v p"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Out of office",
+      "variants": [
+        "ooo"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": " OOO ",
+      "variants": [
+        "o o o"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Best wishes",
+      "variants": [
+        "best wishes"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Take care",
+      "variants": [
+        "take care"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Have a great day",
+      "variants": [
+        "have a great day"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Let me know what you think",
+      "variants": [
+        "let me know what you think"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Happy to help",
+      "variants": [
+        "happy to help"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Thanks for your understanding",
+      "variants": [
+        "thanks for your understanding"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Please let me know",
+      "variants": [
+        "please let me know"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Please confirm receipt",
+      "variants": [
+        "please confirm receipt"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Awaiting your response",
+      "variants": [
+        "awaiting your response"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Looking forward to collaborating",
+      "variants": [
+        "looking forward to collaborating"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Thank you for considering",
+      "variants": [
+        "thanks for considering"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "With appreciation",
+      "variants": [
+        "with appreciation"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Good morning",
+      "variants": [
+        "good morning"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Good afternoon",
+      "variants": [
+        "good afternoon"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Good evening",
+      "variants": [
+        "good evening"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Dear Sir",
+      "variants": [
+        "dear sir"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Dear Madam",
+      "variants": [
+        "dear madam"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "To whom it may concern",
+      "variants": [
+        "to whom it may concern"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Subject to",
+      "variants": [
+        "subject to"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Re:",
+      "variants": [
+        "re colon",
+        "r e"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "Fwd:",
+      "variants": [
+        "f w d colon",
+        "forward colon"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "Attachment",
+      "variants": [
+        "attachment"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Invoice",
+      "variants": [
+        "invoice"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Receipt",
+      "variants": [
+        "receipt"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Meeting invitation",
+      "variants": [
+        "meeting invitation"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Calendar invite",
+      "variants": [
+        "calendar invite"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Zoom link",
+      "variants": [
+        "zoom link"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Google Meet",
+      "variants": [
+        "google meet"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Microsoft Teams",
+      "variants": [
+        "microsoft teams"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    }
+  ]
+}

--- a/src-tauri/resources/profiles/general.json
+++ b/src-tauri/resources/profiles/general.json
@@ -1,0 +1,643 @@
+{
+  "id": "wisper-general-v1",
+  "name": "General",
+  "description": "Common brands, products, places and proper nouns",
+  "version": "2026-09-03",
+  "author": "Wisper",
+  "update_url": "",
+  "entries": [
+    {
+      "phrase": "Wisper",
+      "variants": [
+        "whisper",
+        "whispur"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "LinkedIn",
+      "variants": [
+        "linked in"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "YouTube",
+      "variants": [
+        "you tube"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "macOS",
+      "variants": [
+        "mac os",
+        "mack os"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "iPhone",
+      "variants": [
+        "eye phone"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "iPad",
+      "variants": [
+        "eye pad"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Android",
+      "variants": [
+        "android"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Windows",
+      "variants": [
+        "windows"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Linux",
+      "variants": [
+        "linux"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Ubuntu",
+      "variants": [
+        "ubuntu"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Wi-Fi",
+      "variants": [
+        "wifi",
+        "wee fee",
+        "why fee"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Bluetooth",
+      "variants": [
+        "blue tooth"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "USB-C",
+      "variants": [
+        "u s b c",
+        "usb c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "HDMI",
+      "variants": [
+        "h d m i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Google",
+      "variants": [
+        "goggle"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ChatGPT",
+      "variants": [
+        "chat g p t"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Muse",
+      "variants": [
+        "clod"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Gemini",
+      "variants": [
+        "gemini"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Copilot",
+      "variants": [
+        "co pilot"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Notion",
+      "variants": [
+        "notion"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Figma",
+      "variants": [
+        "figma"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Slack",
+      "variants": [
+        "slack"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Zoom",
+      "variants": [
+        "zoom"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Teams",
+      "variants": [
+        "teams"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Spotify",
+      "variants": [
+        "spotify"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Netflix",
+      "variants": [
+        "netflix"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Amazon",
+      "variants": [
+        "amazon"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Flipkart",
+      "variants": [
+        "flip kart"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Swiggy",
+      "variants": [
+        "swiggy"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Zomato",
+      "variants": [
+        "zomato"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Paytm",
+      "variants": [
+        "pay t m"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "PhonePe",
+      "variants": [
+        "phone pe"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "UPI",
+      "variants": [
+        "u p i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Aadhaar",
+      "variants": [
+        "adhar"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "PAN",
+      "variants": [
+        "pan card"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GST",
+      "variants": [
+        "g s t"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "IRCTC",
+      "variants": [
+        "i r c t c"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Ola",
+      "variants": [
+        "ola"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Uber",
+      "variants": [
+        "uber"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "IndiGo",
+      "variants": [
+        "indigo"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Air India",
+      "variants": [
+        "air india"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Taj",
+      "variants": [
+        "taj"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Tata",
+      "variants": [
+        "tata"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Infosys",
+      "variants": [
+        "infosys"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Wipro",
+      "variants": [
+        "wipro"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TCS",
+      "variants": [
+        "t c s"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Reliance",
+      "variants": [
+        "reliance"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Adani",
+      "variants": [
+        "adani"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Mahindra",
+      "variants": [
+        "mahindra"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Bharat",
+      "variants": [
+        "bharat"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Hindustan",
+      "variants": [
+        "hindustan"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Kolkata",
+      "variants": [
+        "calcutta"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Mumbai",
+      "variants": [
+        "bombay"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Delhi",
+      "variants": [
+        "delhi"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Bengaluru",
+      "variants": [
+        "bangalore"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Hyderabad",
+      "variants": [
+        "hyderabad"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Chennai",
+      "variants": [
+        "chennai"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Pune",
+      "variants": [
+        "pune"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Jaipur",
+      "variants": [
+        "jaipur"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Ahmedabad",
+      "variants": [
+        "ahmedabad"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "OK",
+      "variants": [
+        "okay",
+        "o k"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Instagram",
+      "variants": [
+        "instagram"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Facebook",
+      "variants": [
+        "facebook"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Twitter",
+      "variants": [
+        "twitter"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "X",
+      "variants": [
+        "x"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "WhatsApp",
+      "variants": [
+        "whats app"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Telegram",
+      "variants": [
+        "telegram"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Discord",
+      "variants": [
+        "discord"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Reddit",
+      "variants": [
+        "reddit"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Quora",
+      "variants": [
+        "quora"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Medium",
+      "variants": [
+        "medium"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Substack",
+      "variants": [
+        "sub stack"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Canva",
+      "variants": [
+        "canva"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Adobe",
+      "variants": [
+        "adobe"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Photoshop",
+      "variants": [
+        "photoshop"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Illustrator",
+      "variants": [
+        "illustrator"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Premiere Pro",
+      "variants": [
+        "premier pro"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "polish",
+      "variants": [
+        "police",
+        "pollish",
+        "poll ish",
+        "Polish"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    }
+  ]
+}

--- a/src-tauri/resources/profiles/messaging.json
+++ b/src-tauri/resources/profiles/messaging.json
@@ -1,0 +1,515 @@
+{
+  "id": "wisper-messaging-v1",
+  "name": "Messaging",
+  "description": "Everyday chat phrases, short forms and quick replies",
+  "version": "2026-09-03",
+  "author": "Wisper",
+  "update_url": "",
+  "entries": [
+    {
+      "phrase": "on my way",
+      "variants": [
+        "on my weigh"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "running late",
+      "variants": [
+        "running laid"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "call me when you can",
+      "variants": [
+        "call me when u can"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "no worries",
+      "variants": [
+        "no worry's"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "sounds good",
+      "variants": [
+        "sounds goods"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "let's catch up",
+      "variants": [
+        "lets catch up"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "talk soon",
+      "variants": [
+        "talk soons"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "on the way",
+      "variants": [
+        "on the weigh"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "see you soon",
+      "variants": [
+        "see u soon"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "BRB",
+      "variants": [
+        "be right back",
+        "b r b"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "OMW",
+      "variants": [
+        "o m w",
+        "on my way"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TTYL",
+      "variants": [
+        "t t y l",
+        "talk to you later"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "LOL",
+      "variants": [
+        "l o l",
+        "laugh out loud"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GTG",
+      "variants": [
+        "g t g",
+        "got to go"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "IDK",
+      "variants": [
+        "i d k",
+        "i dont know"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TBH",
+      "variants": [
+        "t b h",
+        "to be honest"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "IMO",
+      "variants": [
+        "i m o",
+        "in my opinion"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "IMHO",
+      "variants": [
+        "i m h o"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "FYI",
+      "variants": [
+        "f y i"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "NVM",
+      "variants": [
+        "n v m",
+        "never mind"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ETA",
+      "variants": [
+        "e t a"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TBD",
+      "variants": [
+        "t b d",
+        "to be decided"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TBA",
+      "variants": [
+        "t b a",
+        "to be announced"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ASAP",
+      "variants": [
+        "a sap",
+        "a s a p"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "DM me",
+      "variants": [
+        "d m me",
+        "direct message me"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ping me",
+      "variants": [
+        "ping mes"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "got it",
+      "variants": [
+        "got its"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "noted",
+      "variants": [
+        "noteds"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "will do",
+      "variants": [
+        "will dos"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "on it",
+      "variants": [
+        "on its"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Let's go",
+      "variants": [
+        "lets go"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "See you tomorrow",
+      "variants": [
+        "see you tomorrow"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Can we reschedule",
+      "variants": [
+        "can we reschedule"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Are you free",
+      "variants": [
+        "are you free"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Call you later",
+      "variants": [
+        "call you later"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Text me",
+      "variants": [
+        "text me"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Share location",
+      "variants": [
+        "share location"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Sent from my iPhone",
+      "variants": [
+        "sent from my iphone"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "haha",
+      "variants": [
+        "hahas"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "hehe",
+      "variants": [
+        "hehes"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "OMG",
+      "variants": [
+        "o m g",
+        "oh my god"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "WTF",
+      "variants": [
+        "w t f"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "BTW",
+      "variants": [
+        "b t w",
+        "by the way"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "ICYMI",
+      "variants": [
+        "i c y m i",
+        "in case you missed it"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TL;DR",
+      "variants": [
+        "t l d r",
+        "too long didnt read"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "FOMO",
+      "variants": [
+        "fomo"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "YOLO",
+      "variants": [
+        "yolo"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GOAT",
+      "variants": [
+        "g o a t"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "IRL",
+      "variants": [
+        "i r l",
+        "in real life"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "DM",
+      "variants": [
+        "d m"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "AFK",
+      "variants": [
+        "a f k",
+        "away from keyboard"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GG",
+      "variants": [
+        "g g",
+        "good game"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "GLHF",
+      "variants": [
+        "g l h f",
+        "good luck have fun"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "BBS",
+      "variants": [
+        "b b s",
+        "be back soon"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "TTFN",
+      "variants": [
+        "t t f n",
+        "ta ta for now"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "LMK",
+      "variants": [
+        "l m k",
+        "let me know"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "N/A",
+      "variants": [
+        "n slash a",
+        "n a"
+      ],
+      "caseSensitive": true,
+      "wholeWord": false
+    },
+    {
+      "phrase": "ETA 5 mins",
+      "variants": [
+        "eta 5 mins"
+      ],
+      "caseSensitive": true,
+      "wholeWord": true
+    },
+    {
+      "phrase": "On my way home",
+      "variants": [
+        "on my way home"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    },
+    {
+      "phrase": "Stuck in traffic",
+      "variants": [
+        "stuck in traffic"
+      ],
+      "caseSensitive": false,
+      "wholeWord": true
+    }
+  ]
+}

--- a/src-tauri/src/dictionary.rs
+++ b/src-tauri/src/dictionary.rs
@@ -1,0 +1,785 @@
+//! Dictionary profiles: shareable packs of custom-words entries.
+//!
+//! The underlying storage stays the existing `words` table (`words.rs`).
+//! Importing a profile inserts its entries as regular rows tagged with
+//! `profile_id`. Editing a row detaches it (`profile_id = NULL`) so the
+//! user's customization survives profile removal. Toggling a profile off
+//! makes `apply_words` / `words_prompt_hint` skip its rows without deleting.
+//!
+//! Bundled profiles are compiled in via `include_str!` (no runtime path
+//! resolution, works in dev and prod). Custom profiles are imported from
+//! JSON text supplied by the frontend (file picker via `<input type=file>`)
+//! or fetched from a URL.
+
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+fn default_whole_word() -> bool {
+    true
+}
+
+/// Accepts `"a, b"` or `["a", "b"]` for ergonomics in hand-written JSON.
+fn deserialize_variants<'de, D>(d: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+    struct VariantsVisitor;
+    impl<'de> Visitor<'de> for VariantsVisitor {
+        type Value = String;
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a string or an array of strings")
+        }
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<String, E> {
+            Ok(v.to_string())
+        }
+        fn visit_string<E: de::Error>(self, v: String) -> Result<String, E> {
+            Ok(v)
+        }
+        fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<String, A::Error> {
+            let mut parts: Vec<String> = Vec::new();
+            while let Some(s) = seq.next_element::<String>()? {
+                parts.push(s);
+            }
+            Ok(parts.join(", "))
+        }
+        fn visit_none<E: de::Error>(self) -> Result<String, E> {
+            Ok(String::new())
+        }
+        fn visit_unit<E: de::Error>(self) -> Result<String, E> {
+            Ok(String::new())
+        }
+    }
+    d.deserialize_any(VariantsVisitor)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileEntryInput {
+    #[serde(default)]
+    pub phrase: String,
+    #[serde(default, deserialize_with = "deserialize_variants")]
+    pub variants: String,
+    #[serde(default)]
+    pub case_sensitive: bool,
+    #[serde(default = "default_whole_word")]
+    pub whole_word: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileFile {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub author: String,
+    #[serde(default)]
+    pub update_url: String,
+    #[serde(default)]
+    pub entries: Vec<ProfileEntryInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileMeta {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub source: String,
+    pub version: String,
+    pub update_url: String,
+    pub entry_count: i64,
+    pub active: bool,
+    /// For bundled listings: already imported into the DB.
+    pub imported: bool,
+    pub imported_at: String,
+    #[serde(default)]
+    pub has_update: bool,
+    #[serde(default)]
+    pub bundled_entry_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportResult {
+    pub profile_id: String,
+    pub added: i64,
+    pub updated: i64,
+    pub unchanged: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileUpdate {
+    pub profile_id: String,
+    pub name: String,
+    pub current_version: String,
+    pub latest_version: String,
+    pub url: String,
+}
+
+// ---------------------------------------------------------------------------
+// Bundled profiles (compiled in)
+// ---------------------------------------------------------------------------
+
+const BUNDLED_DEVELOPER: &str = include_str!("../resources/profiles/developer.json");
+const BUNDLED_EMAIL: &str = include_str!("../resources/profiles/email.json");
+const BUNDLED_MESSAGING: &str = include_str!("../resources/profiles/messaging.json");
+const BUNDLED_GENERAL: &str = include_str!("../resources/profiles/general.json");
+
+fn bundled_jsons() -> Vec<&'static str> {
+    vec![
+        BUNDLED_DEVELOPER,
+        BUNDLED_EMAIL,
+        BUNDLED_MESSAGING,
+        BUNDLED_GENERAL,
+    ]
+}
+
+fn content_hash(text: &str) -> String {
+    let mut h = DefaultHasher::new();
+    text.hash(&mut h);
+    format!("{:016x}", h.finish())
+}
+
+fn normalize_variants(raw: &str) -> String {
+    raw.split([',', '\n'])
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers (same `words.db` connection as `words.rs`)
+// ---------------------------------------------------------------------------
+
+fn imported_map() -> std::collections::HashMap<String, (String, String, bool, String)> {
+    // id -> (version, content_hash, active, imported_at)
+    let mut map = std::collections::HashMap::new();
+    let conn = crate::words::WordsManager::conn();
+    let mut stmt = match conn.prepare(
+        "SELECT id, version, content_hash, active, imported_at FROM dictionary_profiles",
+    ) {
+        Ok(s) => s,
+        Err(_) => return map,
+    };
+    if let Ok(rows) = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, i64>(3)? != 0,
+            row.get::<_, String>(4)?,
+        ))
+    }) {
+        for r in rows.flatten() {
+            map.insert(r.0, (r.1, r.2, r.3, r.4));
+        }
+    }
+    map
+}
+
+fn refresh_entry_counts() {
+    let conn = crate::words::WordsManager::conn();
+    // Recompute for every profile so takeovers / removals can't leave stale counts.
+    let ids: Vec<String> = conn
+        .prepare("SELECT id FROM dictionary_profiles")
+        .and_then(|mut s| {
+            s.query_map([], |r| r.get::<_, String>(0))?
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .unwrap_or_default();
+    for id in ids {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM words WHERE profile_id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        let _ = conn.execute(
+            "UPDATE dictionary_profiles SET entry_count = ?1 WHERE id = ?2",
+            params![count, id],
+        );
+    }
+}
+
+/// Core import. `raw` is the original JSON text (used for the content hash).
+/// Phrase ownership is global and case-insensitive: the importing profile
+/// takes over any existing row with the same phrase (including user-detached
+/// rows), which makes re-imports idempotent and self-healing.
+fn import_profile_text(raw: &str, source: &str) -> Result<ImportResult, String> {
+    let pf: ProfileFile =
+        serde_json::from_str(raw).map_err(|e| format!("Invalid profile JSON: {e}"))?;
+    let id = pf.id.trim().to_string();
+    if id.is_empty() {
+        return Err("Profile id cannot be empty".into());
+    }
+    if pf.name.trim().is_empty() {
+        return Err("Profile name cannot be empty".into());
+    }
+    if pf.entries.is_empty() {
+        return Err("Profile has no entries".into());
+    }
+    if id.len() > 128 {
+        return Err("Profile id is too long (max 128 chars)".into());
+    }
+
+    let hash = content_hash(raw);
+    let mgr = crate::words::WordsManager::new();
+    {
+        let conn = crate::words::WordsManager::conn();
+        conn.execute(
+            "INSERT INTO dictionary_profiles
+                 (id, name, description, source, version, update_url, content_hash, active)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1)
+             ON CONFLICT(id) DO UPDATE SET
+                 name = excluded.name,
+                 description = excluded.description,
+                 source = excluded.source,
+                 version = excluded.version,
+                 update_url = excluded.update_url,
+                 content_hash = excluded.content_hash,
+                 imported_at = datetime('now')",
+            params![
+                id,
+                pf.name.trim(),
+                pf.description.trim(),
+                source,
+                pf.version.trim(),
+                pf.update_url.trim(),
+                hash,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    let mut added = 0i64;
+    let mut updated = 0i64;
+    let mut unchanged = 0i64;
+    for e in &pf.entries {
+        let phrase = e.phrase.trim();
+        if phrase.is_empty() {
+            continue;
+        }
+        if phrase.len() > 256 {
+            continue;
+        }
+        let variants = normalize_variants(&e.variants);
+        // Scope the lookup so the mutex guard drops before any insert/update
+        // below (std Mutex is not reentrant — holding it across add_with_profile
+        // deadlocks).
+        let existing: Option<(i64, String, i64, i64, Option<String>)> = {
+            let conn = crate::words::WordsManager::conn();
+            conn.query_row(
+                "SELECT id, variants, case_sensitive, whole_word, profile_id
+                 FROM words WHERE LOWER(phrase) = LOWER(?1) LIMIT 1",
+                params![phrase],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get::<_, Option<String>>(4).unwrap_or(None),
+                    ))
+                },
+            )
+            .ok()
+        };
+        match existing {
+            None => {
+                mgr.add_with_profile(
+                    phrase,
+                    &variants,
+                    e.case_sensitive,
+                    e.whole_word,
+                    false,
+                    Some(&id),
+                )
+                .map_err(|e| e.to_string())?;
+                added += 1;
+            }
+            Some((row_id, old_variants, old_cs, old_ww, old_pid)) => {
+                let same_content = old_variants == variants
+                    && old_cs == (e.case_sensitive as i64)
+                    && old_ww == (e.whole_word as i64)
+                    && old_pid.as_deref() == Some(id.as_str());
+                if same_content {
+                    unchanged += 1;
+                } else {
+                    let conn = crate::words::WordsManager::conn();
+                    conn.execute(
+                        "UPDATE words SET variants = ?1, case_sensitive = ?2,
+                         whole_word = ?3, profile_id = ?4 WHERE id = ?5",
+                        params![
+                            variants,
+                            e.case_sensitive as i64,
+                            e.whole_word as i64,
+                            id,
+                            row_id
+                        ],
+                    )
+                    .map_err(|e| e.to_string())?;
+                    updated += 1;
+                }
+            }
+        }
+    }
+    if added == 0 && updated == 0 && unchanged == 0 {
+        return Err("Profile has no valid entries (all phrases empty)".into());
+    }
+    refresh_entry_counts();
+    crate::words::clear_words_regex_cache();
+    Ok(ImportResult {
+        profile_id: id,
+        added,
+        updated,
+        unchanged,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn list_bundled_profiles() -> Result<Vec<ProfileMeta>, String> {
+    let imported = imported_map();
+    let mut out = Vec::new();
+    for raw in bundled_jsons() {
+        let pf: ProfileFile =
+            serde_json::from_str(raw).map_err(|e| format!("Bad bundled profile: {e}"))?;
+        let bundled_hash = content_hash(raw);
+        let bundled_len = pf.entries.len() as i64;
+        let (imported_flag, active, imported_at, entry_count, has_update) =
+            match imported.get(&pf.id) {
+                Some((imp_ver, imp_hash, a, at)) => {
+                    let count = crate::words::WordsManager::conn()
+                        .query_row(
+                            "SELECT COUNT(*) FROM words WHERE profile_id = ?1",
+                            params![pf.id],
+                            |r| r.get::<_, i64>(0),
+                        )
+                        .unwrap_or(0);
+                    // Has update if version changed or content hash differs.
+                    // Using hash catches entry additions even when version is bumped forgotten.
+                    let upd = imp_ver.trim() != pf.version.trim() || imp_hash.trim() != bundled_hash.trim();
+                    (true, *a, at.clone(), count, upd)
+                }
+                None => (false, true, String::new(), bundled_len, false),
+            };
+        out.push(ProfileMeta {
+            id: pf.id,
+            name: pf.name,
+            description: pf.description,
+            source: "bundled".into(),
+            version: pf.version,
+            update_url: pf.update_url,
+            entry_count,
+            active,
+            imported: imported_flag,
+            imported_at,
+            has_update,
+            bundled_entry_count: bundled_len,
+        });
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+pub fn list_imported_profiles() -> Result<Vec<ProfileMeta>, String> {
+    let conn = crate::words::WordsManager::conn();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, description, source, version, update_url,
+                    entry_count, active, imported_at
+             FROM dictionary_profiles ORDER BY imported_at DESC",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(ProfileMeta {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                description: row.get(2)?,
+                source: row.get(3)?,
+                version: row.get(4)?,
+                update_url: row.get(5)?,
+                entry_count: row.get(6)?,
+                active: row.get::<_, i64>(7)? != 0,
+                imported: true,
+                imported_at: row.get(8)?,
+                has_update: false,
+                bundled_entry_count: 0,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows)
+}
+
+#[tauri::command]
+pub fn import_bundled_profile(profile_id: String) -> Result<ImportResult, String> {
+    let wanted = profile_id.trim();
+    for raw in bundled_jsons() {
+        let pf: ProfileFile =
+            serde_json::from_str(raw).map_err(|e| format!("Bad bundled profile: {e}"))?;
+        if pf.id == wanted {
+            return import_profile_text(raw, "bundled");
+        }
+    }
+    Err(format!("No bundled profile with id '{wanted}'"))
+}
+
+/// Import from JSON text. The frontend reads the file via `<input type=file>`
+/// so no dialog/fs plugin is needed on the Rust side.
+#[tauri::command]
+pub fn import_profile_from_json(json_text: String) -> Result<ImportResult, String> {
+    if json_text.len() > 2_000_000 {
+        return Err("Profile file is too large (max 2 MB)".into());
+    }
+    import_profile_text(&json_text, "imported")
+}
+
+#[tauri::command]
+pub async fn import_profile_from_url(url: String) -> Result<ImportResult, String> {
+    let url = url.trim().to_string();
+    if !(url.starts_with("https://") || url.starts_with("http://localhost")) {
+        return Err("Only https:// URLs are allowed (http://localhost for testing)".into());
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(20))
+            .build()
+            .map_err(|e| e.to_string())?;
+        let resp = client.get(&url).send().map_err(|e| e.to_string())?;
+        let ct = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        if !ct.contains("json") && !ct.is_empty() {
+            return Err(format!("Unexpected content type '{ct}' (expected JSON)"));
+        }
+        let text = resp.text().map_err(|e| e.to_string())?;
+        if text.len() > 2_000_000 {
+            return Err("Downloaded profile is too large (max 2 MB)".into());
+        }
+        import_profile_text(&text, "downloaded")
+    })
+    .await
+    .map_err(|_| "Profile download failed unexpectedly".to_string())?
+}
+
+#[tauri::command]
+pub fn set_profile_active(profile_id: String, active: bool) -> Result<(), String> {
+    let conn = crate::words::WordsManager::conn();
+    let n = conn
+        .execute(
+            "UPDATE dictionary_profiles SET active = ?1 WHERE id = ?2",
+            params![active as i64, profile_id.trim()],
+        )
+        .map_err(|e| e.to_string())?;
+    if n == 0 {
+        return Err("Profile not found".into());
+    }
+    crate::words::clear_words_regex_cache();
+    Ok(())
+}
+
+/// Deletes all rows owned by the profile plus the profile record.
+/// Rows the user edited after import were detached (`profile_id = NULL`)
+/// and are kept.
+#[tauri::command]
+pub fn remove_profile(profile_id: String) -> Result<i64, String> {
+    let pid = profile_id.trim().to_string();
+    let conn = crate::words::WordsManager::conn();
+    let deleted: i64 = {
+        let n = conn
+            .execute("DELETE FROM words WHERE profile_id = ?1", params![pid])
+            .map_err(|e| e.to_string())? as i64;
+        conn.execute(
+            "DELETE FROM dictionary_profiles WHERE id = ?1",
+            params![pid],
+        )
+        .map_err(|e| e.to_string())?;
+        n
+    };
+    crate::words::clear_words_regex_cache();
+    Ok(deleted)
+}
+
+fn build_export(profile: &ProfileMeta) -> Result<String, String> {
+    let conn = crate::words::WordsManager::conn();
+    let mut stmt = conn
+        .prepare(
+            "SELECT phrase, variants, case_sensitive, whole_word FROM words
+             WHERE profile_id = ?1 ORDER BY LOWER(phrase)",
+        )
+        .map_err(|e| e.to_string())?;
+    let entries = stmt
+        .query_map(params![profile.id], |row| {
+            Ok(ProfileEntryInput {
+                phrase: row.get(0)?,
+                variants: row.get(1)?,
+                case_sensitive: row.get::<_, i64>(2)? != 0,
+                whole_word: row.get::<_, i64>(3)? != 0,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    let file = ProfileFile {
+        id: profile.id.clone(),
+        name: profile.name.clone(),
+        description: profile.description.clone(),
+        version: profile.version.clone(),
+        author: "Wisper export".into(),
+        update_url: profile.update_url.clone(),
+        entries,
+    };
+    serde_json::to_string_pretty(&file).map_err(|e| e.to_string())
+}
+
+/// Returns the profile JSON text; the frontend saves it via Blob download.
+#[tauri::command]
+pub fn export_profile(profile_id: String) -> Result<String, String> {
+    let profiles = list_imported_profiles()?;
+    let pid = profile_id.trim();
+    let profile = profiles
+        .iter()
+        .find(|p| p.id == pid)
+        .ok_or_else(|| "Profile not found".to_string())?;
+    build_export(profile)
+}
+
+/// Exports all user-added rows (`profile_id IS NULL`) as a shareable file.
+#[tauri::command]
+pub fn export_user_words() -> Result<String, String> {
+    let conn = crate::words::WordsManager::conn();
+    let mut stmt = conn
+        .prepare(
+            "SELECT phrase, variants, case_sensitive, whole_word FROM words
+             WHERE profile_id IS NULL ORDER BY LOWER(phrase)",
+        )
+        .map_err(|e| e.to_string())?;
+    let entries = stmt
+        .query_map([], |row| {
+            Ok(ProfileEntryInput {
+                phrase: row.get(0)?,
+                variants: row.get(1)?,
+                case_sensitive: row.get::<_, i64>(2)? != 0,
+                whole_word: row.get::<_, i64>(3)? != 0,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    if entries.is_empty() {
+        return Err("No custom words to export".into());
+    }
+    let file = ProfileFile {
+        id: "wisper-user-export".into(),
+        name: "My words".into(),
+        description: "Exported from Wisper".into(),
+        version: String::new(),
+        author: "Wisper export".into(),
+        update_url: String::new(),
+        entries,
+    };
+    serde_json::to_string_pretty(&file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn check_profile_updates() -> Result<Vec<ProfileUpdate>, String> {
+    let profiles = list_imported_profiles()?;
+    let with_url: Vec<ProfileMeta> = profiles
+        .into_iter()
+        .filter(|p| !p.update_url.trim().is_empty())
+        .collect();
+    if with_url.is_empty() {
+        return Ok(Vec::new());
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        for p in with_url {
+            let text = match client.get(p.update_url.trim()).send() {
+                Ok(r) => match r.text() {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                },
+                Err(_) => continue,
+            };
+            let remote: ProfileFile = match serde_json::from_str(&text) {
+                Ok(f) => f,
+                Err(_) => continue,
+            };
+            if remote.id != p.id {
+                continue;
+            }
+            if !remote.version.trim().is_empty() && remote.version.trim() != p.version.trim() {
+                out.push(ProfileUpdate {
+                    profile_id: p.id.clone(),
+                    name: p.name.clone(),
+                    current_version: p.version.clone(),
+                    latest_version: remote.version,
+                    url: p.update_url.clone(),
+                });
+            }
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|_| "Update check failed unexpectedly".to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_id(tag: &str) -> String {
+        format!("__test_profile_{tag}__")
+    }
+
+    fn cleanup(id: &str) {
+        let conn = crate::words::WordsManager::conn();
+        let _ = conn.execute("DELETE FROM words WHERE profile_id = ?1", params![id]);
+        let _ = conn.execute("DELETE FROM dictionary_profiles WHERE id = ?1", params![id]);
+        crate::words::clear_words_regex_cache();
+    }
+
+    fn sample_json(id: &str) -> String {
+        serde_json::json!({
+            "id": id,
+            "name": format!("Test {id}"),
+            "description": "unit test profile",
+            "version": "2024-01-01",
+            "author": "test",
+            "entries": [
+                {"phrase": format!("KuberTest{0}", id.len()), "variants": "kuber test phrase", "caseSensitive": false, "wholeWord": true},
+                {"phrase": "TestPhraseTwo", "variants": ["test phrase 2", "tee pee two"], "caseSensitive": false, "wholeWord": true}
+            ]
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn import_is_idempotent() {
+        let id = test_id("idempotent");
+        cleanup(&id);
+        let raw = sample_json(&id);
+        let r1 = import_profile_text(&raw, "imported").expect("first import");
+        assert_eq!(r1.added, 2, "first import adds all");
+        let r2 = import_profile_text(&raw, "imported").expect("second import");
+        assert_eq!(r2.added, 0, "re-import adds nothing");
+        assert_eq!(r2.unchanged, 2, "re-import all unchanged");
+        cleanup(&id);
+    }
+
+    #[test]
+    fn toggle_skips_and_restores_entries() {
+        let id = test_id("toggle");
+        cleanup(&id);
+        // Unique phrase unlikely to collide with a real user DB.
+        // Use multi-char variant to avoid colliding with single-letter
+        // entries in bundled profiles (e.g. "X" -> "x").
+        let phrase = "ZxqToggleWisp";
+        let variant = "zxq toggle wisp";
+        let raw = serde_json::json!({
+            "id": id, "name": "toggle", "version": "1",
+            "entries": [{"phrase": phrase, "variants": variant, "wholeWord": true}]
+        })
+        .to_string();
+        import_profile_text(&raw, "imported").expect("import");
+        assert_eq!(
+            crate::words::apply_words(&format!("say {variant} now")),
+            format!("say {phrase} now")
+        );
+        set_profile_active(id.clone(), false).expect("deactivate");
+        assert_eq!(
+            crate::words::apply_words(&format!("say {variant} now")),
+            format!("say {variant} now"),
+            "inactive profile must not apply"
+        );
+        set_profile_active(id.clone(), true).expect("reactivate");
+        assert_eq!(
+            crate::words::apply_words(&format!("say {variant} now")),
+            format!("say {phrase} now")
+        );
+        cleanup(&id);
+    }
+
+    #[test]
+    fn remove_keeps_user_edited_rows() {
+        let id = test_id("remove");
+        cleanup(&id);
+        let phrase = "ZxqKeepWisp";
+        let raw = serde_json::json!({
+            "id": id, "name": "remove", "version": "1",
+            "entries": [{"phrase": phrase, "variants": "z x q keep wisp", "wholeWord": true}]
+        })
+        .to_string();
+        import_profile_text(&raw, "imported").expect("import");
+        // Simulate user edit -> detaches the row.
+        let row_id: i64 = crate::words::WordsManager::conn()
+            .query_row(
+                "SELECT id FROM words WHERE LOWER(phrase) = LOWER(?1)",
+                params![phrase],
+                |r| r.get(0),
+            )
+            .expect("row exists");
+        crate::words::WordsManager::new()
+            .update(row_id, phrase, "z x q keep wisp, custom variant", false, true)
+            .expect("edit");
+        let deleted = remove_profile(id.clone()).expect("remove");
+        assert_eq!(deleted, 0, "edited row was detached, nothing owned left");
+        let still_there: i64 = crate::words::WordsManager::conn()
+            .query_row(
+                "SELECT COUNT(*) FROM words WHERE LOWER(phrase) = LOWER(?1)",
+                params![phrase],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        assert_eq!(still_there, 1, "user-edited row survives profile removal");
+        // Test cleanup.
+        let _ = crate::words::WordsManager::new().delete(row_id);
+        cleanup(&id);
+    }
+
+    #[test]
+    fn rejects_bad_json() {
+        assert!(import_profile_text("not json", "imported").is_err());
+        assert!(import_profile_text(r#"{"id":"","name":"x","entries":[]}"#, "imported").is_err());
+        assert!(import_profile_text(
+            r#"{"id":"a","name":"b","entries":[{"phrase":"","variants":"x"}]}"#,
+            "imported"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn bundled_profiles_parse() {
+        for raw in bundled_jsons() {
+            let pf: ProfileFile = serde_json::from_str(raw).expect("bundled must parse");
+            assert!(!pf.id.is_empty());
+            assert!(!pf.name.is_empty());
+            assert!(!pf.entries.is_empty(), "profile {} is empty", pf.id);
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app_info;
 pub mod audio;
 pub mod coordinator;
+pub mod dictionary;
 pub mod engine;
 pub mod history;
 pub mod hotkey;
@@ -844,6 +845,16 @@ pub fn run() {
             words::get_ignored_terms,
             words::unignore_word_term,
             words::add_ignored_to_dictionary,
+            dictionary::list_bundled_profiles,
+            dictionary::list_imported_profiles,
+            dictionary::import_bundled_profile,
+            dictionary::import_profile_from_json,
+            dictionary::import_profile_from_url,
+            dictionary::set_profile_active,
+            dictionary::remove_profile,
+            dictionary::export_profile,
+            dictionary::export_user_words,
+            dictionary::check_profile_updates,
             history::get_history_entries,
             history::get_history_count,
             history::get_history_stats,

--- a/src-tauri/src/words.rs
+++ b/src-tauri/src/words.rs
@@ -31,6 +31,10 @@ fn clear_regex_cache_all() {
     }
 }
 
+pub(crate) fn clear_words_regex_cache() {
+    clear_regex_cache_all();
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WordEntry {
     pub id: i64,
@@ -41,6 +45,8 @@ pub struct WordEntry {
     pub auto: bool,
     pub hits: i64,
     pub created_at: String,
+    #[serde(default)]
+    pub profile_id: Option<String>,
 }
 
 impl WordEntry {
@@ -99,9 +105,37 @@ static WORDS_CONN: once_cell::sync::Lazy<Mutex<Connection>> = once_cell::sync::L
             );
             CREATE TABLE IF NOT EXISTS ignored_terms (
                 term TEXT PRIMARY KEY COLLATE NOCASE
+            );
+            CREATE TABLE IF NOT EXISTS dictionary_profiles (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                source TEXT NOT NULL DEFAULT 'imported',
+                version TEXT DEFAULT '',
+                update_url TEXT DEFAULT '',
+                entry_count INTEGER NOT NULL DEFAULT 0,
+                content_hash TEXT DEFAULT '',
+                active INTEGER NOT NULL DEFAULT 1,
+                imported_at TEXT DEFAULT (datetime('now'))
             );",
     ) {
         eprintln!("[words] failed to create table: {e}");
+    }
+    // Migration for existing DBs: words.profile_id tracks which imported
+    // profile owns a row (NULL = user-added). ALTER fails if the column
+    // already exists, so probe pragma first.
+    {
+        let has_profile_id: bool = conn
+            .prepare("SELECT profile_id FROM words LIMIT 0")
+            .is_ok();
+        if !has_profile_id {
+            if let Err(e) = conn.execute_batch(
+                "ALTER TABLE words ADD COLUMN profile_id TEXT DEFAULT NULL;
+                 CREATE INDEX IF NOT EXISTS words_profile_idx ON words(profile_id);",
+            ) {
+                eprintln!("[words] profile_id migration failed: {e}");
+            }
+        }
     }
     Mutex::new(conn)
 });
@@ -114,7 +148,7 @@ impl WordsManager {
         Self
     }
 
-    fn conn() -> std::sync::MutexGuard<'static, Connection> {
+    pub(crate) fn conn() -> std::sync::MutexGuard<'static, Connection> {
         WORDS_CONN.lock().unwrap_or_else(|e| e.into_inner())
     }
 
@@ -129,7 +163,7 @@ impl WordsManager {
     pub fn all(&self) -> SqlResult<Vec<WordEntry>> {
         let conn = Self::conn();
         let mut stmt = conn.prepare(
-            "SELECT id, phrase, variants, case_sensitive, whole_word, auto, hits, created_at
+            "SELECT id, phrase, variants, case_sensitive, whole_word, auto, hits, created_at, profile_id
              FROM words ORDER BY hits DESC, id DESC",
         )?;
         let rows = stmt
@@ -143,6 +177,7 @@ impl WordsManager {
                     auto: row.get::<_, i64>(5)? != 0,
                     hits: row.get(6)?,
                     created_at: row.get(7)?,
+                    profile_id: row.get::<_, Option<String>>(8).unwrap_or(None),
                 })
             })?
             .collect::<SqlResult<Vec<_>>>()?;
@@ -157,16 +192,78 @@ impl WordsManager {
         whole_word: bool,
         auto: bool,
     ) -> SqlResult<i64> {
+        self.add_with_profile(phrase, variants, case_sensitive, whole_word, auto, None)
+    }
+
+    pub fn add_with_profile(
+        &self,
+        phrase: &str,
+        variants: &str,
+        case_sensitive: bool,
+        whole_word: bool,
+        auto: bool,
+        profile_id: Option<&str>,
+    ) -> SqlResult<i64> {
+        let norm_phrase = phrase.trim();
+        // Check for existing phrase (case-insensitive) to merge instead of duplicating
+        let existing: Option<(i64, String)> = {
+            let conn = Self::conn();
+            conn.query_row(
+                "SELECT id, variants FROM words WHERE LOWER(phrase) = LOWER(?1) LIMIT 1",
+                params![norm_phrase],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok()
+        };
+        if let Some((existing_id, existing_variants)) = existing {
+            // Merge variants case-insensitive, keep order: existing first, then new
+            let mut seen = std::collections::HashSet::new();
+            let mut merged: Vec<String> = Vec::new();
+            for v in existing_variants.split([',', '\n']).map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                let low = v.to_lowercase();
+                if seen.insert(low) {
+                    merged.push(v.to_string());
+                }
+            }
+            for v in variants.split([',', '\n']).map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                let low = v.to_lowercase();
+                if seen.insert(low.clone()) {
+                    // Also avoid adding phrase itself as variant (redundant)
+                    if low != norm_phrase.to_lowercase() {
+                        merged.push(v.to_string());
+                    }
+                }
+            }
+            let merged_str = merged.join(", ");
+            let conn = Self::conn();
+            // If merging via manual add (profile_id None) into a profile-owned row, detach to user-owned
+            // If merging via profile import (profile_id Some), take ownership
+            if let Some(pid) = profile_id {
+                conn.execute(
+                    "UPDATE words SET variants = ?1, profile_id = ?2 WHERE id = ?3",
+                    params![merged_str, pid, existing_id],
+                )?;
+            } else {
+                conn.execute(
+                    "UPDATE words SET variants = ?1, profile_id = NULL WHERE id = ?2",
+                    params![merged_str, existing_id],
+                )?;
+            }
+            drop(conn);
+            clear_regex_cache_for(existing_id);
+            return Ok(existing_id);
+        }
         let conn = Self::conn();
         conn.execute(
-            "INSERT INTO words (phrase, variants, case_sensitive, whole_word, auto)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO words (phrase, variants, case_sensitive, whole_word, auto, profile_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
-                phrase,
+                norm_phrase,
                 variants,
                 case_sensitive as i64,
                 whole_word as i64,
-                auto as i64
+                auto as i64,
+                profile_id
             ],
         )?;
         let id = conn.last_insert_rowid();
@@ -184,9 +281,11 @@ impl WordsManager {
         whole_word: bool,
     ) -> SqlResult<()> {
         let conn = Self::conn();
+        // User editing an entry detaches it from its profile (profile_id -> NULL),
+        // so removing the profile later keeps the user's customized row.
         conn.execute(
-            "UPDATE words SET phrase = ?1, variants = ?2, case_sensitive = ?3, whole_word = ?4
-             WHERE id = ?5",
+            "UPDATE words SET phrase = ?1, variants = ?2, case_sensitive = ?3, whole_word = ?4,
+             profile_id = NULL WHERE id = ?5",
             params![
                 phrase,
                 variants,
@@ -269,6 +368,24 @@ impl WordsManager {
         let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
         Ok(rows.flatten().collect())
     }
+
+    /// IDs of profiles the user has toggled off. Entries owned by these
+    /// profiles are skipped by `apply_words` / `words_prompt_hint`.
+    /// Returns empty set when the profiles table doesn't exist yet.
+    pub fn inactive_profile_ids(&self) -> std::collections::HashSet<String> {
+        let mut set = std::collections::HashSet::new();
+        let conn = Self::conn();
+        let mut stmt = match conn.prepare("SELECT id FROM dictionary_profiles WHERE active = 0") {
+            Ok(s) => s,
+            Err(_) => return set,
+        };
+        if let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(0)) {
+            for id in rows.flatten() {
+                set.insert(id);
+            }
+        }
+        set
+    }
 }
 
 pub fn apply_words(text: &str) -> String {
@@ -277,9 +394,15 @@ pub fn apply_words(text: &str) -> String {
         Ok(e) => e,
         Err(_) => return text.to_string(),
     };
+    let inactive = mgr.inactive_profile_ids();
 
     let mut out = text.to_string();
     for entry in &entries {
+        if let Some(pid) = entry.profile_id.as_deref() {
+            if inactive.contains(pid) {
+                continue;
+            }
+        }
         let phrase = entry.phrase.trim().to_string();
         if phrase.is_empty() {
             continue;
@@ -346,10 +469,16 @@ pub fn words_prompt_hint(text: &str) -> String {
         Ok(e) if !e.is_empty() => e,
         _ => return String::new(),
     };
+    let inactive = mgr.inactive_profile_ids();
     let lower = text.to_lowercase();
 
     let mut lines = Vec::new();
     for e in entries.iter() {
+        if let Some(pid) = e.profile_id.as_deref() {
+            if inactive.contains(pid) {
+                continue;
+            }
+        }
         let phrase = e.phrase.trim();
         if phrase.is_empty() {
             continue;

--- a/src/components/DictionaryProfiles.tsx
+++ b/src/components/DictionaryProfiles.tsx
@@ -1,0 +1,348 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { DictionaryProfile, ProfileImportResult, ProfileUpdate } from "../types";
+import { SectionCard } from "./SectionCard";
+import { Switch } from "./Switch";
+import { useToast } from "./ToastContext";
+
+export function notifyWordsChanged() {
+  window.dispatchEvent(new CustomEvent("wisper:words-changed"));
+}
+
+function downloadJson(filename: string, text: string) {
+  const blob = new Blob([text], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function shortProfileId(id: string): string {
+  return id.replace(/^wisper-/, "").replace(/-v\d+$/, "");
+}
+
+export function DictionaryProfiles() {
+  const { addToast } = useToast();
+  const [bundled, setBundled] = useState<DictionaryProfile[]>([]);
+  const [imported, setImported] = useState<DictionaryProfile[]>([]);
+  const [updates, setUpdates] = useState<ProfileUpdate[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [url, setUrl] = useState("");
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [b, i] = await Promise.all([
+        invoke<DictionaryProfile[]>("list_bundled_profiles"),
+        invoke<DictionaryProfile[]>("list_imported_profiles"),
+      ]);
+      setBundled(b);
+      setImported(i);
+    } catch (e) {
+      console.error(e);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function run(id: string, fn: () => Promise<unknown>, after?: () => void) {
+    setBusy(id);
+    try {
+      await fn();
+      await load();
+      notifyWordsChanged();
+      after?.();
+    } catch (e: any) {
+      addToast(String(e?.message ?? e), "error");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onImportBundled(p: DictionaryProfile) {
+    await run(`import-${p.id}`, async () => {
+      const r = await invoke<ProfileImportResult>("import_bundled_profile", { profileId: p.id });
+      addToast(`${p.name}: +${r.added} new, ${r.updated} updated`, "success");
+    });
+  }
+
+  async function onToggle(p: DictionaryProfile, active: boolean) {
+    await run(`toggle-${p.id}`, async () => {
+      await invoke("set_profile_active", { profileId: p.id, active });
+      addToast(active ? `${p.name} enabled` : `${p.name} paused — ${p.entryCount} entries skipped`, "info");
+    });
+  }
+
+  async function onRemove(p: DictionaryProfile) {
+    if (!confirm(`Remove the "${p.name}" profile? ${p.entryCount} entries will be deleted (words you edited are kept).`)) return;
+    await run(`remove-${p.id}`, async () => {
+      const n = await invoke<number>("remove_profile", { profileId: p.id });
+      addToast(`${p.name} removed (${n} entries)`, "success");
+    });
+  }
+
+  async function onFilePicked(file: File) {
+    const text = await file.text();
+    await run("import-file", async () => {
+      const r = await invoke<ProfileImportResult>("import_profile_from_json", { jsonText: text });
+      addToast(`Imported ${r.profileId}: +${r.added} new, ${r.updated} updated`, "success");
+    });
+  }
+
+  async function onImportUrl() {
+    const u = url.trim();
+    if (!u) return;
+    await run("import-url", async () => {
+      const r = await invoke<ProfileImportResult>("import_profile_from_url", { url: u });
+      setUrl("");
+      addToast(`Imported ${r.profileId}: +${r.added} new, ${r.updated} updated`, "success");
+    });
+  }
+
+  async function onExport(p: DictionaryProfile) {
+    try {
+      const text = await invoke<string>("export_profile", { profileId: p.id });
+      downloadJson(`${p.id}.json`, text);
+      addToast(`${p.name} exported`, "success");
+    } catch (e: any) {
+      addToast(String(e?.message ?? e), "error");
+    }
+  }
+
+  async function onExportMine() {
+    try {
+      const text = await invoke<string>("export_user_words");
+      downloadJson("wisper-my-words.json", text);
+      addToast("Your words exported", "success");
+    } catch (e: any) {
+      addToast(String(e?.message ?? e), "error");
+    }
+  }
+
+  async function onCheckUpdates() {
+    setChecking(true);
+    try {
+      const u = await invoke<ProfileUpdate[]>("check_profile_updates");
+      setUpdates(u);
+      addToast(u.length === 0 ? "All profiles are up to date" : `${u.length} update${u.length !== 1 ? "s" : ""} available`, u.length === 0 ? "info" : "success");
+    } catch (e: any) {
+      addToast(String(e?.message ?? e), "error");
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  async function onApplyUpdate(u: ProfileUpdate) {
+    await run(`update-${u.profileId}`, async () => {
+      const r = await invoke<ProfileImportResult>("import_profile_from_url", { url: u.url });
+      setUpdates((prev) => prev.filter((x) => x.profileId !== u.profileId));
+      addToast(`${u.name} updated to v${u.latestVersion} (+${r.added}, ${r.updated} updated)`, "success");
+    });
+  }
+
+  const customProfiles = imported.filter((p) => p.source !== "bundled");
+
+  return (
+    <div className="space-y-3">
+      <SectionCard className="card-enter">
+        <div>
+          <h2 className="label-soft">Dictionary profiles</h2>
+          <p className="text-[11px] text-muted mt-1 leading-relaxed">
+            Ready-made word packs for your kind of work. Import one, pause it anytime, or share your own as a file.
+          </p>
+        </div>
+
+        <div className="space-y-1.5 mt-3">
+          {bundled.map((p) => (
+            <div
+              key={p.id}
+              className="flex items-center gap-2 bg-elevated/30 rounded-lg px-2.5 py-2 ring-1 ring-stroke/60"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-mono text-ink">{p.name}</span>
+                  <span className="text-[9px] font-mono text-muted/70">
+                    {p.imported ? `${p.entryCount} / ${p.bundledEntryCount} entries` : `${p.entryCount} terms`} · v{p.version}
+                    {p.hasUpdate && <span className="ml-1 text-amber-500">· update available</span>}
+                  </span>
+                </div>
+                {p.description && (
+                  <p className="text-[10px] font-mono text-muted truncate" title={p.description}>
+                    {p.description}
+                  </p>
+                )}
+              </div>
+              <div className="ml-auto flex items-center gap-2 shrink-0">
+                {p.imported ? (
+                  <>
+                    {p.hasUpdate && (
+                      <button
+                        onClick={() => onImportBundled(p)}
+                        disabled={busy === `import-${p.id}`}
+                        className="text-[10px] font-mono bg-accent/15 text-accent hover:bg-accent/25 rounded px-2 py-1 transition-colors cursor-pointer disabled:opacity-40"
+                        title={`Update available: ${p.bundledEntryCount} terms in latest (you have ${p.entryCount})`}
+                      >
+                        {busy === `import-${p.id}` ? "Updating…" : `Update · +${Math.max(0, p.bundledEntryCount - p.entryCount)} new`}
+                      </button>
+                    )}
+                    <Switch
+                      label={`${p.name} active`}
+                      checked={p.active}
+                      onChange={(v) => onToggle(p, v)}
+                    />
+                    <button
+                      onClick={() => onExport(p)}
+                      className="text-[10px] font-mono text-muted hover:text-ink transition-colors cursor-pointer"
+                    >
+                      Export
+                    </button>
+                    <button
+                      onClick={() => onRemove(p)}
+                      disabled={busy === `remove-${p.id}`}
+                      className="text-[10px] font-mono text-muted hover:text-red-400 transition-colors cursor-pointer disabled:opacity-40"
+                    >
+                      Remove
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    onClick={() => onImportBundled(p)}
+                    disabled={busy === `import-${p.id}`}
+                    className="text-[10px] font-mono text-accent hover:text-accent/80 transition-colors cursor-pointer disabled:opacity-40"
+                  >
+                    {busy === `import-${p.id}` ? "Adding…" : "Add"}
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard className="card-enter">
+        <div>
+          <h2 className="label-soft">Share profiles</h2>
+          <p className="text-[11px] text-muted mt-1 leading-relaxed">
+            Import a profile file someone shared with you, or export your own words to share.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 mt-3">
+          <input
+            ref={fileRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              e.target.value = "";
+              if (f) onFilePicked(f);
+            }}
+          />
+          <button
+            onClick={() => fileRef.current?.click()}
+            disabled={busy === "import-file"}
+            className="bg-elevated/50 text-ink rounded-md px-3 py-1.5 text-xs font-mono ring-1 ring-stroke hover:ring-accent/40 disabled:opacity-60 transition-all cursor-pointer"
+          >
+            {busy === "import-file" ? "Importing…" : "Import from file…"}
+          </button>
+          <button
+            onClick={onExportMine}
+            className="bg-elevated/50 text-ink rounded-md px-3 py-1.5 text-xs font-mono ring-1 ring-stroke hover:ring-accent/40 transition-all cursor-pointer"
+          >
+            Export my words…
+          </button>
+          <button
+            onClick={onCheckUpdates}
+            disabled={checking}
+            className="bg-elevated/50 text-ink rounded-md px-3 py-1.5 text-xs font-mono ring-1 ring-stroke hover:ring-accent/40 disabled:opacity-60 transition-all cursor-pointer"
+          >
+            {checking ? "Checking…" : "Check for updates"}
+          </button>
+        </div>
+        <div className="flex gap-2 mt-2">
+          <input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && onImportUrl()}
+            placeholder="https://…/profile.json"
+            aria-label="Profile URL"
+            className="flex-1 min-w-0 bg-elevated/30 rounded-md px-2.5 py-1.5 text-xs font-mono text-ink placeholder:text-muted/40 ring-1 ring-stroke/60 focus:outline-none focus:ring-accent/50"
+          />
+          <button
+            onClick={onImportUrl}
+            disabled={!url.trim() || busy === "import-url"}
+            className="bg-accent/15 text-accent rounded-md px-3 py-1.5 text-xs font-mono hover:bg-accent/25 disabled:opacity-40 disabled:cursor-not-allowed transition-all cursor-pointer"
+          >
+            {busy === "import-url" ? "Fetching…" : "Add URL"}
+          </button>
+        </div>
+
+        {customProfiles.length > 0 && (
+          <div className="space-y-1.5 mt-3 pt-3 border-t border-stroke/30">
+            <p className="text-[9px] font-mono text-muted tracking-[0.12em] uppercase">Imported</p>
+            {customProfiles.map((p) => (
+              <div
+                key={p.id}
+                className="flex items-center gap-2 bg-elevated/30 rounded-lg px-2.5 py-2 ring-1 ring-stroke/60"
+              >
+                <div className="flex-1 min-w-0">
+                  <span className="text-xs font-mono text-ink">{p.name}</span>
+                  <span className="text-[9px] font-mono text-muted/70 ml-2">
+                    {p.entryCount} entries · {p.source}
+                  </span>
+                </div>
+                <div className="ml-auto flex items-center gap-2 shrink-0">
+                  <Switch label={`${p.name} active`} checked={p.active} onChange={(v) => onToggle(p, v)} />
+                  <button
+                    onClick={() => onExport(p)}
+                    className="text-[10px] font-mono text-muted hover:text-ink transition-colors cursor-pointer"
+                  >
+                    Export
+                  </button>
+                  <button
+                    onClick={() => onRemove(p)}
+                    className="text-[10px] font-mono text-muted hover:text-red-400 transition-colors cursor-pointer"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {updates.length > 0 && (
+          <div className="space-y-1.5 mt-3 pt-3 border-t border-stroke/30">
+            <p className="text-[9px] font-mono text-muted tracking-[0.12em] uppercase">Updates available</p>
+            {updates.map((u) => (
+              <div
+                key={u.profileId}
+                className="flex items-center gap-2 bg-accent/5 rounded-lg px-2.5 py-2 ring-1 ring-accent/30"
+              >
+                <span className="text-xs font-mono text-ink flex-1 truncate">
+                  {u.name} <span className="text-muted">v{u.currentVersion} → v{u.latestVersion}</span>
+                </span>
+                <button
+                  onClick={() => onApplyUpdate(u)}
+                  disabled={busy === `update-${u.profileId}`}
+                  className="text-[10px] font-mono text-accent hover:text-accent/80 transition-colors cursor-pointer disabled:opacity-40 shrink-0"
+                >
+                  {busy === `update-${u.profileId}` ? "Updating…" : "Update"}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </SectionCard>
+    </div>
+  );
+}
+
+export { shortProfileId };

--- a/src/components/WordsManager.tsx
+++ b/src/components/WordsManager.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
-import { WordEntry, WordSuggestion } from "../types";
+import { WordEntry, WordSuggestion, DictionaryProfile } from "../types";
 import { SectionCard } from "./SectionCard";
 import { Switch } from "./Switch";
 import { Input } from "./ui/Input";
@@ -30,6 +30,8 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
   const [ignored, setIgnored] = useState<string[]>([]);
   const [showImport, setShowImport] = useState(false);
   const [dictQuery, setDictQuery] = useState("");
+  const phraseRef = useRef<HTMLInputElement>(null);
+  const [inactiveProfiles, setInactiveProfiles] = useState<Set<string>>(new Set());
 
   const loadIgnored = useCallback(async () => {
     try {
@@ -42,8 +44,12 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
 
   const load = useCallback(async () => {
     try {
-      const v = await invoke<WordEntry[]>("get_words");
+      const [v, profiles] = await Promise.all([
+        invoke<WordEntry[]>("get_words"),
+        invoke<DictionaryProfile[]>("list_imported_profiles"),
+      ]);
       setEntries(v);
+      setInactiveProfiles(new Set(profiles.filter((p) => !p.active).map((p) => p.id)));
     } catch (e) {
       console.error(e);
     }
@@ -52,10 +58,18 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
   useEffect(() => {
     load();
     loadIgnored();
+    const onChanged = () => {
+      load();
+      loadIgnored();
+    };
+    window.addEventListener("wisper:words-changed", onChanged);
+    return () => window.removeEventListener("wisper:words-changed", onChanged);
   }, [load, loadIgnored]);
 
   async function addEntry() {
     if (!phrase.trim()) return;
+    const norm = phrase.trim().toLowerCase();
+    const existing = entries.find((e) => e.phrase.toLowerCase() === norm);
     setError("");
     try {
       await invoke("add_word_entry", {
@@ -67,8 +81,13 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
       });
       setPhrase("");
       setVariants("");
+      phraseRef.current?.focus();
       await load();
-      addToast("Term added", "success");
+      if (existing) {
+        addToast(`Updated ${existing.phrase} — variants merged`, "success");
+      } else {
+        addToast("Term added", "success");
+      }
     } catch (e: any) {
       setError(String(e));
       addToast("Failed to add term", "error");
@@ -87,6 +106,8 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
   }
 
   async function acceptSuggestion(s: WordSuggestion) {
+    const norm = s.phrase.trim().toLowerCase();
+    const existing = entries.find((e) => e.phrase.toLowerCase() === norm);
     try {
       await invoke("add_word_entry", {
         phrase: s.phrase,
@@ -97,7 +118,11 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
       });
       setSuggestions((prev) => prev.filter((x) => x.phrase !== s.phrase));
       await load();
-      addToast("Term added", "success");
+      if (existing) {
+        addToast(`Updated ${existing.phrase} — variants merged`, "success");
+      } else {
+        addToast("Term added", "success");
+      }
     } catch (e) {
       console.error(e);
       addToast("Failed to add term", "error");
@@ -145,11 +170,13 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
 
   const handleImport = async (paste: string) => {
     const lines = paste.trim().split(/\r?\n/).filter(Boolean);
-    let added = 0, skipped = 0;
+    let added = 0, merged = 0;
     for (const line of lines) {
       try {
         const [phrase, variants] = line.split("|").map(s => s.trim());
         if (!phrase) continue;
+        // Check if phrase already exists (case-insensitive) to count as merged
+        const exists = entries.some((e) => e.phrase.toLowerCase() === phrase.toLowerCase());
         await invoke("add_word_entry", {
           phrase,
           variants: variants || "",
@@ -157,14 +184,14 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
           wholeWord: true,
           auto: false,
         });
-        added++;
+        if (exists) merged++;
+        else added++;
       } catch (e) {
-        if (String(e).includes("UNIQUE")) skipped++;
-        else console.error(e);
+        console.error(e);
       }
     }
     await load();
-    return { added, skipped };
+    return { added, skipped: merged };
   };
 
   const filteredEntries = dictQuery.trim()
@@ -224,7 +251,7 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
             {suggestions.length > 0 && (
               <>
                 <p className="text-[10px] font-mono text-muted/70 leading-relaxed">
-                  Edit the <span className="text-ink">correct spelling</span> on the left; add how it was <span className="text-ink">misheard</span> on the right.
+                  Edit how it was <span className="text-ink">misheard</span> on the left; <span className="text-ink">correct spelling</span> on the right.
                 </p>
                 <div className="space-y-1.5 max-h-48 overflow-y-auto custom-scrollbar pr-0.5">
                   {suggestions.map((s, i) => (
@@ -232,17 +259,6 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
                       key={i}
                       className="flex items-center gap-2 bg-elevated/30 rounded-lg px-2.5 py-2 ring-1 ring-stroke/60 min-w-0"
                     >
-                      <div className="w-28 shrink-0">
-                        <Input
-                          variant="ghost"
-                          value={s.phrase}
-                          onChange={(e) => updateSuggestion(i, { phrase: e.target.value })}
-                          placeholder="Correct spelling"
-                          aria-label="Correct spelling"
-                          title="Correct spelling to use"
-                        />
-                      </div>
-                      <span className="text-[10px] font-mono text-muted/60 shrink-0" title="will be replaced by the correct spelling">←</span>
                       <div className="flex-1 min-w-0">
                         <Input
                           variant="ghost"
@@ -256,6 +272,17 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
                           aria-label="Misheard variants"
                           title="Comma-separated misheard forms"
                           className="text-[10px] text-muted placeholder:text-muted/40"
+                        />
+                      </div>
+                      <span className="text-[10px] font-mono text-muted/60 shrink-0" title="misheard will be replaced by correct spelling">→</span>
+                      <div className="w-28 shrink-0">
+                        <Input
+                          variant="ghost"
+                          value={s.phrase}
+                          onChange={(e) => updateSuggestion(i, { phrase: e.target.value })}
+                          placeholder="Correct spelling"
+                          aria-label="Correct spelling"
+                          title="Correct spelling to use"
                         />
                       </div>
                       <div className="ml-auto flex items-center gap-2 shrink-0">
@@ -290,6 +317,7 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
 
             <div className="space-y-1.5">
               <Input
+                ref={phraseRef}
                 value={phrase}
                 onChange={(e) => setPhrase(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && addEntry()}
@@ -338,6 +366,7 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
                     value={dictQuery}
                     onChange={(e) => setDictQuery(e.target.value)}
                     placeholder="Search dictionary…"
+                    aria-label="Search dictionary"
                     className="w-full pl-8 pr-3"
                   />
                 </div>
@@ -348,15 +377,40 @@ export function WordsManager({ wordsEnabled, onToggle, wordsAutoScan, onToggleAu
                     filteredEntries.map((e) => (
                       <div
                         key={e.id}
-                        className="flex items-center gap-2 bg-elevated/30 rounded-lg px-2.5 py-2 ring-1 ring-stroke/60"
+                        className={`flex items-center gap-2 bg-elevated/30 rounded-lg px-2.5 py-2 ring-1 ring-stroke/60 ${e.profile_id && inactiveProfiles.has(e.profile_id) ? "opacity-50" : ""}`}
+                        title={e.profile_id && inactiveProfiles.has(e.profile_id) ? "Profile paused — this entry is currently skipped" : undefined}
                       >
-                        <span className="text-xs font-mono text-ink shrink-0">{e.phrase}</span>
-                        {e.variants && (
-                          <span className="text-[10px] font-mono text-muted truncate" title={e.variants}>
-                            ← {e.variants}
-                          </span>
-                        )}
+                        <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                          {e.variants ? (
+                            <>
+                              <span className="text-[11px] font-mono text-muted truncate" title={e.variants}>
+                                {e.variants}
+                              </span>
+                              <span className="text-[10px] text-muted/40 shrink-0">→</span>
+                              <span className="text-xs font-mono font-medium text-ink shrink-0" title={e.phrase}>
+                                {e.phrase}
+                              </span>
+                            </>
+                          ) : (
+                            <span className="text-xs font-mono text-ink" title={e.phrase}>
+                              {e.phrase}
+                            </span>
+                          )}
+                        </div>
                         <div className="ml-auto flex items-center gap-2 shrink-0">
+                          {!!e.profile_id && inactiveProfiles.has(e.profile_id) && (
+                            <span className="text-[9px] font-mono bg-elevated text-muted px-1.5 py-0.5 rounded ring-1 ring-stroke/50">
+                              paused
+                            </span>
+                          )}
+                          {e.profile_id && (
+                            <span
+                              className="text-[9px] font-mono bg-elevated text-muted px-1.5 py-0.5 rounded ring-1 ring-stroke/50"
+                              title={`From profile: ${e.profile_id}. Editing detaches it from the profile.`}
+                            >
+                              {e.profile_id.replace(/^wisper-/, "").replace(/-v\d+$/, "")}
+                            </span>
+                          )}
                           {e.auto && (
                             <span className="text-[9px] font-mono bg-accent/10 text-accent/80 px-1.5 py-0.5 rounded">auto</span>
                           )}
@@ -483,7 +537,7 @@ function ImportModal({ onClose, onImport }: { onClose: () => void; onImport: (te
         </form>
         {result && (
           <div className="text-[10px] font-mono text-ready text-center pt-2 border-t border-stroke/30">
-            Imported {result.added} term{result.added !== 1 ? "s" : ""}, skipped {result.skipped}
+            Imported {result.added} new, {result.skipped} merged
           </div>
         )}
       </div>

--- a/src/components/WordsTab.tsx
+++ b/src/components/WordsTab.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { AppSettings, WordSuggestion } from "../types";
 import { ResetButton } from "./ResetButton";
 import { WordsManager } from "./WordsManager";
+import { DictionaryProfiles } from "./DictionaryProfiles";
 import { useToast } from "./ToastContext";
 
 interface WordsTabProps {
@@ -56,6 +57,8 @@ export function WordsTab({ settings, onSave, onReset }: WordsTabProps) {
         onScan={onScan}
         setSuggestions={setSuggestions}
       />
+
+      <DictionaryProfiles />
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,37 @@ export interface WordEntry {
   auto: boolean;
   hits: number;
   created_at: string;
+  profile_id?: string | null;
+}
+
+export interface DictionaryProfile {
+  id: string;
+  name: string;
+  description: string;
+  source: string;
+  version: string;
+  updateUrl: string;
+  entryCount: number;
+  active: boolean;
+  imported: boolean;
+  importedAt: string;
+  hasUpdate: boolean;
+  bundledEntryCount: number;
+}
+
+export interface ProfileImportResult {
+  profileId: string;
+  added: number;
+  updated: number;
+  unchanged: number;
+}
+
+export interface ProfileUpdate {
+  profileId: string;
+  name: string;
+  currentVersion: string;
+  latestVersion: string;
+  url: string;
 }
 
 export interface WordSuggestion {


### PR DESCRIPTION
Adds profile-aware dictionary on top of existing words DB.

**Backend**
- `words.rs`: `profile_id` column + `dictionary_profiles` table (id, name, description, source, version, update_url, entry_count, content_hash, active), merge-dedup on `LOWER(phrase)` (single row per destination, variants merged), inactive filtering in `apply_words`/`words_prompt_hint`, detach on edit, cache clear helper
- `dictionary.rs`: bundled packs via `include_str!`, import (bundled/file/url https-only 2MB cap), duplicate-safe takeover (`added/updated/unchanged`), `set_profile_active` toggle, `remove_profile` (keeps edited rows), `export_profile`/`export_user_words`, `check_profile_updates` with `has_update`/`bundledEntryCount` (hash+version), 5 tests
- `lib.rs`: register 9 commands
- `resources/profiles`: developer 253 (incl. polish→police fix), email 67, messaging 60, general 77

**UI**
- `DictionaryProfiles.tsx`: bundled cards (Add/Update +N new + hasUpdate badge, active Switch, Export/Remove), share section (file <input> / URL import, export my words, check for updates), imported + updates sections, dispatches `wisper:words-changed`
- `WordsTab.tsx`: mount profiles below manager
- `WordsManager.tsx`: `variants → phrase` row, profile + paused dimming/badge, live reload on event, focus to Correct spelling after Add, search aria-label, import merged count, suggestions unified to →, duplicate toast

**Behavior**
- Adding same destination merges variants into one row
- Toggling a profile off dims its rows and skips them in transcription (no delete)
- Updating a bundled pack only adds new terms (hash/version check, no duplicates)

Verified: `cargo test --lib` 9/9, `pnpm build` ok, branch pushed.