### PR TITLE
feat(ui): polish sidebar, history and tray

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wisper",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Turn your voice into text right on your device, with your privacy always in your hands.",
   "author": "Tarak Shaw <taraksh01@gmail.com>",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "wisper"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "arboard",
  "cpal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wisper"
-version = "3.1.1"
+version = "3.2.0"
 description = "Turn your voice into text right on your device, with your privacy always in your hands."
 authors = ["Tarak Shaw <taraksh01@gmail.com>"]
 edition = "2021"

--- a/src-tauri/src/coordinator.rs
+++ b/src-tauri/src/coordinator.rs
@@ -137,6 +137,7 @@ pub static ENABLED_LANGUAGES: Mutex<Vec<String>> = Mutex::new(Vec::new());
 pub static INPUT_DEVICE: Mutex<String> = Mutex::new(String::new()); // empty = system default
 pub static PASTE_METHOD: Mutex<String> = Mutex::new(String::new());
 pub static PASTE_TOOL: Mutex<String> = Mutex::new(String::new());
+pub static PASTE_ADD_TRAILING_SPACE: AtomicBool = AtomicBool::new(true);
 pub static WORDS_ENABLED: AtomicBool = AtomicBool::new(true);
 pub static WORDS_AUTO_SCAN: AtomicBool = AtomicBool::new(true);
 pub static SOUND_ENABLED: AtomicBool = AtomicBool::new(true);
@@ -670,7 +671,17 @@ fn run_pipeline(samples: Vec<f32>, device_sr: u32, cancel: CancelToken, my_seq: 
                         thread::sleep(std::time::Duration::from_millis(10));
                     }
                 }
-                if let Err(e) = paste_text(&final_text, &paste_method) {
+                let to_paste = if crate::coordinator::PASTE_ADD_TRAILING_SPACE
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    && !final_text.is_empty()
+                    && !final_text.ends_with(' ')
+                    && !final_text.ends_with('\n')
+                {
+                    format!("{} ", final_text)
+                } else {
+                    final_text.clone()
+                };
+                if let Err(e) = paste_text(&to_paste, &paste_method) {
                     eprintln!("Paste failed: {}", e);
                 }
                 let duration_ms = if device_sr > 0 {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -60,6 +60,8 @@ pub struct AppSettings {
     pub hotkey_mode: String,
     pub paste_method: String,
     pub paste_tool: String,
+    #[serde(default = "default_true")]
+    pub paste_add_trailing_space: bool,
     pub vad_enabled: bool,
     pub vad_threshold: f32,
     pub noise_suppression_enabled: bool,
@@ -168,6 +170,7 @@ impl Default for AppSettings {
             hotkey_mode: "push-to-talk".into(),
             paste_method: "Direct Typing".into(),
             paste_tool: "auto".into(),
+            paste_add_trailing_space: true,
             vad_enabled: true,
             vad_threshold: 0.01,
             noise_suppression_enabled: false,
@@ -308,6 +311,10 @@ pub fn sync_runtime(settings: &AppSettings) {
             .unwrap_or_else(|e| e.into_inner());
         *tool = settings.paste_tool.clone();
     }
+    crate::coordinator::PASTE_ADD_TRAILING_SPACE.store(
+        settings.paste_add_trailing_space,
+        std::sync::atomic::Ordering::Relaxed,
+    );
     {
         let mut v = crate::coordinator::INPUT_DEVICE
             .lock()

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -332,7 +332,16 @@ pub fn sync_runtime(settings: &AppSettings) {
         let mut v = crate::coordinator::CLOUD_API_KEY
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        *v = settings.voice_api_key.clone();
+        *v = match settings.engine_provider.as_str() {
+            "openai" => settings.voice_api_key_openai.clone(),
+            "groq" => settings.voice_api_key_groq.clone(),
+            "custom" => settings.voice_api_key_custom.clone(),
+            _ => settings.voice_api_key.clone(),
+        };
+        // Fallback to generic key if provider-specific is empty (migration)
+        if v.trim().is_empty() {
+            *v = settings.voice_api_key.clone();
+        }
     }
     {
         let mut v = crate::coordinator::CLOUD_MODEL

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
-    Emitter, Manager,
+    Manager,
 };
 
 use crate::coordinator::CoordinatorState;
@@ -50,7 +50,7 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
     };
     let s = settings::AppSettings::load();
 
-    // 1. Hotkey + mode
+    // 1. Hotkey — info only (disabled), opens nowhere
     let hk_display = if s.hotkey.is_empty() {
         "F9".into()
     } else {
@@ -61,11 +61,11 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
         app,
         "hotkey",
         format!(
-            "{} · {}",
+            "Hotkey: {} · {}",
             hk_display,
             if is_ptt { "Push to talk" } else { "Toggle" }
         ),
-        true,
+        false,
         None::<&str>,
     )?;
 
@@ -104,10 +104,8 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
         MenuItem::with_id(app, "switch", "Switch engine", false, None::<&str>)?
     };
 
-    // 4. Navigation + Quit
+    // 4. Open + Quit only — no redundant Settings/History (Open restores last tab)
     let open_i = MenuItem::with_id(app, "open", "Open Wisper", true, None::<&str>)?;
-    let settings_i = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
-    let history_i = MenuItem::with_id(app, "history", "History", true, None::<&str>)?;
     let quit_i = MenuItem::with_id(
         app,
         "quit",
@@ -117,21 +115,11 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
     )?;
     let sep1 = PredefinedMenuItem::separator(app)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
-    let sep3 = PredefinedMenuItem::separator(app)?;
 
     let menu = Menu::with_items(
         app,
         &[
-            &hotkey_i,
-            &model_i,
-            &sep1,
-            &switch_i,
-            &sep2,
-            &open_i,
-            &settings_i,
-            &history_i,
-            &sep3,
-            &quit_i,
+            &hotkey_i, &model_i, &sep1, &switch_i, &sep2, &open_i, &quit_i,
         ],
     )?;
     tray.set_menu(Some(menu))?;
@@ -187,9 +175,7 @@ pub fn build_tray(app: &tauri::AppHandle) -> Result<tauri::tray::TrayIcon, tauri
             "unload" => settings::unload_local_model(app),
             "reload" => settings::reload_last_model(app),
             "switch" => settings::switch_engine_mode(app),
-            "settings" => open_tab(app, "general"),
-            "history" => open_tab(app, "history"),
-            "open" | "hotkey" => show_main(app),
+            "open" => show_main(app),
             _ => {}
         })
         .on_tray_icon_event(|tray, event| {
@@ -212,9 +198,4 @@ fn show_main(app: &tauri::AppHandle) {
         let _ = win.show();
         let _ = win.set_focus();
     }
-}
-
-fn open_tab(app: &tauri::AppHandle, tab: &str) {
-    show_main(app);
-    let _ = app.emit("wisper:open-tab", tab);
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -139,11 +139,7 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
     let copy_i = MenuItem::with_id(
         app,
         "copy_last",
-        if has_history {
-            "Copy last transcription"
-        } else {
-            "Copy last transcription"
-        },
+        "Copy last transcription",
         has_history,
         None::<&str>,
     )?;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -131,7 +131,22 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
         MenuItem::with_id(app, "switch", "Switch engine", false, None::<&str>)?
     };
 
-    // 4. Open + Quit only — no redundant Settings/History (Open restores last tab)
+    // 4. Copy last + Open + Quit
+    let has_history = crate::history::HistoryManager::new()
+        .get_history(1, 0)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let copy_i = MenuItem::with_id(
+        app,
+        "copy_last",
+        if has_history {
+            "Copy last transcription"
+        } else {
+            "Copy last transcription"
+        },
+        has_history,
+        None::<&str>,
+    )?;
     let open_i = MenuItem::with_id(app, "open", "Open Wisper", true, None::<&str>)?;
     let quit_i = MenuItem::with_id(
         app,
@@ -142,11 +157,12 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
     )?;
     let sep1 = PredefinedMenuItem::separator(app)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
+    let sep3 = PredefinedMenuItem::separator(app)?;
 
     let menu = Menu::with_items(
         app,
         &[
-            &hotkey_i, &model_i, &sep1, &switch_i, &sep2, &open_i, &quit_i,
+            &hotkey_i, &model_i, &sep1, &switch_i, &sep2, &copy_i, &open_i, &sep3, &quit_i,
         ],
     )?;
     tray.set_menu(Some(menu))?;
@@ -202,6 +218,20 @@ pub fn build_tray(app: &tauri::AppHandle) -> Result<tauri::tray::TrayIcon, tauri
             "unload" => settings::unload_local_model(app),
             "reload" => settings::reload_last_model(app),
             "switch" => settings::switch_engine_mode(app),
+            "copy_last" => {
+                if let Ok(entries) = crate::history::HistoryManager::new().get_history(1, 0) {
+                    if let Some(entry) = entries.first() {
+                        let text = entry
+                            .formatted_text
+                            .as_deref()
+                            .filter(|s| !s.trim().is_empty())
+                            .unwrap_or(&entry.raw_text);
+                        if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                            let _ = clipboard.set_text(text.to_string());
+                        }
+                    }
+                }
+            }
             "open" => show_main(app),
             _ => {}
         })

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -69,8 +69,22 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
         None::<&str>,
     )?;
 
-    // 2. ONE action row - Load or Unload depending on state
-    let model_i = if !s.local_model_file.is_empty() {
+    // 2. ONE action row - shows the ACTIVE engine's model, not always local
+    let model_i = if s.engine_mode == "cloud" {
+        let cloud_label = {
+            let label = match s.engine_provider.as_str() {
+                "openai" => "OpenAI",
+                "groq" => "Groq",
+                _ => "Custom",
+            };
+            if s.engine_model.trim().is_empty() {
+                format!("{label} · not configured")
+            } else {
+                format!("{label} · {}", s.engine_model)
+            }
+        };
+        MenuItem::with_id(app, "cloud_model", cloud_label, false, None::<&str>)?
+    } else if !s.local_model_file.is_empty() {
         MenuItem::with_id(
             app,
             "unload",
@@ -92,7 +106,20 @@ fn rebuild_menu(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
 
     // 3. Switch engine (enabled only when both engines are usable)
     let has_local = !s.local_model_file.is_empty() || !s.last_local_model_file.is_empty();
-    let has_cloud = !s.voice_api_key.is_empty() && !s.engine_model.is_empty();
+    let has_cloud = {
+        let key_ok = match s.engine_provider.as_str() {
+            "openai" => {
+                !s.voice_api_key_openai.trim().is_empty() || !s.voice_api_key.trim().is_empty()
+            }
+            "groq" => !s.voice_api_key_groq.trim().is_empty() || !s.voice_api_key.trim().is_empty(),
+            "custom" => {
+                !s.voice_api_key_custom.trim().is_empty() || !s.voice_api_key.trim().is_empty()
+            }
+            _ => !s.voice_api_key.trim().is_empty(),
+        };
+        let base_ok = s.engine_provider != "custom" || !s.engine_base_url.trim().is_empty();
+        key_ok && !s.engine_model.trim().is_empty() && base_ok
+    };
     let switch_i = if has_local && has_cloud {
         let label = if s.engine_mode == "cloud" {
             "Switch to On-device"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Wisper",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "identifier": "com.taraksh01.wisper",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import { WordsTab } from "./components/WordsTab";
 import { HistoryTab } from "./components/HistoryTab";
 import { AboutTab } from "./components/AboutTab";
 import { DonateTab } from "./components/DonateTab";
-import { UpdateBanner } from "./components/UpdateBanner";
 import { ToastProvider, useToast } from "./components/ToastContext";
 import { storageKey } from "./appConfig";
 import "./styles.css";
@@ -428,7 +427,6 @@ function AppShell() {
         <div className="flex-1 flex flex-col min-w-0">
           <div className="flex-1 overflow-y-auto custom-scrollbar">
             <div className="max-w-[var(--content-max)] mx-auto w-full px-6 py-6">
-              <UpdateBanner />
               <div className="tab-enter">
                 {renderTab()}
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,6 +297,7 @@ function AppShell() {
       case "hotkey": return null; // handled inline in GeneralTab to avoid double toast + to allow rollback on failure
       case "hotkey_mode": return `Mode: ${String(value)}`;
       case "paste_tool": return `Paste tool: ${String(value)}`;
+      case "paste_add_trailing_space": return `Trailing space ${on(Boolean(value))}`;
       case "input_device": return value ? `Microphone: ${String(value)}` : "Microphone: System default";
       case "process_enabled": return `AI processing ${on(Boolean(value))}`;
       case "words_enabled": return `Your dictionary ${on(Boolean(value))}`;
@@ -326,7 +327,7 @@ function AppShell() {
   };
 
   const TAB_FIELDS: Record<string, (keyof AppSettings)[]> = {
-    general: ["autostart", "hotkey", "hotkey_mode", "language", "launch_to_tray", "paste_method", "paste_tool", "vad_enabled", "vad_threshold", "noise_suppression_enabled", "noise_suppression_level", "overlay_enabled", "overlay_position", "sound_enabled", "sound_on_start", "sound_on_done", "sound_on_cancel", "sound_on_error", "input_device", "max_history_entries", "history_retention_mode", "keep_recordings"],
+    general: ["autostart", "hotkey", "hotkey_mode", "language", "launch_to_tray", "paste_method", "paste_tool", "paste_add_trailing_space", "vad_enabled", "vad_threshold", "noise_suppression_enabled", "noise_suppression_level", "overlay_enabled", "overlay_position", "sound_enabled", "sound_on_start", "sound_on_done", "sound_on_cancel", "sound_on_error", "input_device", "max_history_entries", "history_retention_mode", "keep_recordings"],
     engine: ["engine_mode", "engine_provider", "engine_base_url", "voice_api_key", "voice_api_key_openai", "voice_api_key_groq", "voice_api_key_custom", "engine_model", "local_model_file"],
     process: ["process_enabled", "process_provider", "process_base_url", "process_endpoint", "process_timeout_secs", "process_api_key", "process_api_key_openai", "process_api_key_anthropic", "process_api_key_google", "process_api_key_groq", "process_api_key_together", "process_api_key_deepseek", "process_api_key_kimi", "process_api_key_qwen", "process_api_key_glm", "process_api_key_openrouter", "process_api_key_ollama", "process_api_key_opencode_go", "process_api_key_custom", "process_model", "process_max_tokens", "process_agent_profile", "process_agent_name", "process_agent_prompt"],
     words: ["words_enabled", "words_auto_scan"],

--- a/src/components/EngineTab.tsx
+++ b/src/components/EngineTab.tsx
@@ -360,13 +360,29 @@ export function EngineTab({ settings, onSave, onSaveAll }: EngineTabProps) {
               <Field label="Model" value={settings.engine_model} onChange={(v) => onSave("engine_model", v)} />
             )}
 
-            <Field
-              label="API Key"
-              value={settings.voice_api_key}
-              onChange={(v) => onSave("voice_api_key", v)}
-              secret
-              placeholder={settings.engine_provider === "openai" ? "sk-..." : settings.engine_provider === "groq" ? "gsk_..." : "API key"}
-            />
+            {(() => {
+              const keyField =
+                settings.engine_provider === "openai"
+                  ? "voice_api_key_openai"
+                  : settings.engine_provider === "groq"
+                  ? "voice_api_key_groq"
+                  : "voice_api_key_custom";
+              return (
+                <Field
+                  label="API Key"
+                  value={(settings as any)[keyField] || ""}
+                  onChange={(v) => {
+                    const updates: Partial<AppSettings> = {
+                      [keyField]: v,
+                      voice_api_key: v,
+                    } as any;
+                    onSaveAll(updates);
+                  }}
+                  secret
+                  placeholder={settings.engine_provider === "openai" ? "sk-..." : settings.engine_provider === "groq" ? "gsk_..." : "API key"}
+                />
+              );
+            })()}
             <p className="text-[10px] text-muted/70 mt-1">Saved on this device only - it's sent nowhere except to your chosen service.</p>
           </SectionCard>
         </>

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -868,6 +868,17 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
             onChange={(v) => onSave("paste_method", v)}
           />
           <PasteToolControl value={settings.paste_tool} onChange={(v) => onSave("paste_tool", v)} />
+          <div className="flex items-center justify-between gap-3 pt-3 border-t border-stroke">
+            <div>
+              <span className="text-xs text-muted">Add space after paste</span>
+              <p className="text-[10px] font-mono text-muted/60 leading-relaxed">Inserts a space so next dictation continues as new word.</p>
+            </div>
+            <Switch
+              label="Add space after paste"
+              checked={settings.paste_add_trailing_space}
+              onChange={(v) => onSave("paste_add_trailing_space", v)}
+            />
+          </div>
         </div>
       </SectionCard>
 

--- a/src/components/HistoryItem.tsx
+++ b/src/components/HistoryItem.tsx
@@ -108,8 +108,8 @@ export function HistoryItem({
   return (
     <div
       ref={rowRef}
-      className={`group relative rounded-xl px-2.5 py-2 transition-colors ${
-        selected ? "bg-accent/10" : "bg-elevated/30 hover:bg-elevated/60"
+      className={`group relative rounded-xl px-2.5 py-2 transition-all duration-300 ${
+        copied ? "bg-ready/10 ring-1 ring-ready/20" : selected ? "bg-accent/10" : "bg-elevated/30 hover:bg-elevated/60"
       }`}
     >
       <div className="flex items-center gap-1 mb-1">
@@ -175,17 +175,22 @@ export function HistoryItem({
             )}
             <button
               onClick={() => onCopy(entry)}
-              className="p-1 text-muted hover:text-accent rounded transition-colors"
-              title="Copy"
+              className={`p-1 rounded transition-all duration-200 active:scale-90 ${
+                copied ? "text-ready bg-ready/10 scale-110" : "text-muted hover:text-accent hover:bg-elevated"
+              }`}
+              title={copied ? "Copied!" : "Copy"}
             >
               {copied ? (
-                <svg className="w-3.5 h-3.5 text-ready" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg className="w-3.5 h-3.5 text-ready" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M5 13l4 4L19 7" />
                 </svg>
               ) : (
                 <IconCopy className="w-3.5 h-3.5" />
               )}
             </button>
+            {copied && (
+              <span className="text-[10px] font-mono text-ready animate-pulse ml-0.5">Copied!</span>
+            )}
             <button
               onClick={() => onStartEdit(entry)}
               className="p-1 text-muted hover:text-warning rounded transition-colors"

--- a/src/components/HistoryTab.tsx
+++ b/src/components/HistoryTab.tsx
@@ -74,6 +74,13 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [query, setQuery] = useState("");
+  const [todayOpen, setTodayOpen] = useState(() => {
+    try {
+      return localStorage.getItem(storageKey("history-today-open")) === "1";
+    } catch {
+      return false;
+    }
+  });
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [player, setPlayer] = useState<{
     id: number;
@@ -89,6 +96,22 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
   const lifetimeWords = settings.lifetime_words ?? 0;
   const lifetimeDictations = settings.lifetime_dictations ?? 0;
   const lifetimeAvg = lifetimeDictations > 0 ? lifetimeWords / lifetimeDictations : 0;
+
+  const todayStats = useMemo(() => {
+    const today = new Date().toDateString();
+    const todayEntries = history.filter((e) => {
+      try {
+        return new Date(e.created_at).toDateString() === today;
+      } catch {
+        return false;
+      }
+    });
+    const dictations = todayEntries.length;
+    const words = todayEntries.reduce((acc, e) => acc + (e.word_count || 0), 0);
+    // 60 WPM ~= 1 word per second, same as coordinator
+    const saved = words;
+    return { dictations, words, saved, entries: todayEntries };
+  }, [history]);
 
   const filteredHistory = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -328,6 +351,77 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
             </div>
           ))}
         </div>
+      </SectionCard>
+
+      <SectionCard className="card-enter">
+        <button
+          onClick={() => {
+            const next = !todayOpen;
+            setTodayOpen(next);
+            try {
+              localStorage.setItem(storageKey("history-today-open"), next ? "1" : "0");
+            } catch {}
+          }}
+          aria-expanded={todayOpen}
+          className="w-full flex items-center justify-between gap-3 text-left"
+        >
+          <h2 className="label-soft">Today</h2>
+          <span className="flex items-center gap-2 shrink-0">
+            <span className="text-[10px] font-mono text-muted tabular-nums">
+              {todayStats.dictations === 0
+                ? "No activity yet"
+                : `${todayStats.dictations} · ${todayStats.words} words`}
+            </span>
+            <span className="text-[10px] font-mono text-muted/50 hidden sm:inline">
+              {new Date().toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })}
+            </span>
+            <svg
+              className={`w-3.5 h-3.5 text-muted/60 transition-transform duration-200 ${todayOpen ? "rotate-90" : ""}`}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M9 18l6-6-6-6" />
+            </svg>
+          </span>
+        </button>
+        {todayOpen && (
+          <div className="mt-3 space-y-3">
+            <div className="grid grid-cols-3 gap-2">
+              {[
+                { label: "Today", value: String(todayStats.dictations), sub: "dictations" },
+                { label: "Words", value: String(todayStats.words), sub: "words" },
+                {
+                  label: "Saved",
+                  value:
+                    todayStats.saved >= 3600
+                      ? `${Math.floor(todayStats.saved / 3600)}h ${Math.floor((todayStats.saved % 3600) / 60)}m`
+                      : todayStats.saved >= 60
+                      ? `${Math.floor(todayStats.saved / 60)}m ${todayStats.saved % 60}s`
+                      : `${todayStats.saved}s`,
+                  sub: "time saved",
+                },
+              ].map((s) => (
+                <div
+                  key={s.label}
+                  className="bg-elevated/40 rounded-xl px-3 py-3 text-center min-w-0"
+                >
+                  <div className="text-lg font-bold font-mono text-accent tabular-nums truncate leading-none">{s.value}</div>
+                  <div className="text-[9px] font-mono text-muted mt-1.5 tracking-[0.12em] uppercase truncate">{s.label}</div>
+                  <div className="text-[9px] font-mono text-muted/60 truncate">{s.sub}</div>
+                </div>
+              ))}
+            </div>
+            {todayStats.dictations === 0 ? (
+              <p className="text-[11px] text-muted/60 text-center">No dictations yet today — press {settings.hotkey} to start</p>
+            ) : (
+              <p className="text-[10px] font-mono text-muted/50 text-center">Resets at midnight · Lifetime totals above</p>
+            )}
+          </div>
+        )}
       </SectionCard>
 
       <SectionCard className="card-enter flex flex-col h-[457px]">

--- a/src/components/HistoryTab.tsx
+++ b/src/components/HistoryTab.tsx
@@ -11,6 +11,7 @@ import { AudioPlayerPopover } from "./AudioPlayerPopover";
 import { Input } from "./ui/Input";
 import { useToast } from "./ToastContext";
 import { useWindowSize } from "../hooks/useWindowSize";
+import { calcSavedSeconds, formatSaved } from "../utils/timeSaved";
 
 interface HistoryTabProps {
   history: HistoryEntry[];
@@ -108,8 +109,7 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
     });
     const dictations = todayEntries.length;
     const words = todayEntries.reduce((acc, e) => acc + (e.word_count || 0), 0);
-    // 60 WPM ~= 1 word per second, same as coordinator
-    const saved = words;
+    const saved = todayEntries.reduce((acc, e) => acc + calcSavedSeconds(e.word_count || 0, e.duration_ms || 0), 0);
     return { dictations, words, saved, entries: todayEntries };
   }, [history]);
 
@@ -333,11 +333,7 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
             { label: "Avg Words", value: lifetimeAvg.toFixed(1), title: "Lifetime average - never resets" },
             {
               label: "Time saved",
-              value: timeSavedSec >= 3600
-                ? `${Math.floor(timeSavedSec / 3600)}h ${Math.floor((timeSavedSec % 3600) / 60)}m`
-                : timeSavedSec >= 60
-                ? `${Math.floor(timeSavedSec / 60)}m ${timeSavedSec % 60}s`
-                : `${timeSavedSec}s`,
+              value: formatSaved(timeSavedSec),
               title: "Estimated at 60 WPM typing speed - lifetime, never resets",
             },
           ].map((s) => (
@@ -394,16 +390,7 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
               {[
                 { label: "Today", value: String(todayStats.dictations), sub: "dictations" },
                 { label: "Words", value: String(todayStats.words), sub: "words" },
-                {
-                  label: "Saved",
-                  value:
-                    todayStats.saved >= 3600
-                      ? `${Math.floor(todayStats.saved / 3600)}h ${Math.floor((todayStats.saved % 3600) / 60)}m`
-                      : todayStats.saved >= 60
-                      ? `${Math.floor(todayStats.saved / 60)}m ${todayStats.saved % 60}s`
-                      : `${todayStats.saved}s`,
-                  sub: "time saved",
-                },
+                { label: "Saved", value: formatSaved(todayStats.saved), sub: "time saved" },
               ].map((s) => (
                 <div
                   key={s.label}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { AppSettings, tabs } from "../types";
 import { APP_NAME } from "../appConfig";
 import { WisperLogo } from "./WisperLogo";
 import { tabIconMap, IconCloseSmall, IconChevronRight } from "./ui/icons";
+import { SidebarUpdateBanner } from "./SidebarUpdateBanner";
 
 interface SidebarProps {
   activeTab: string;
@@ -135,6 +136,7 @@ export function Sidebar({ activeTab, appState, settings, currentModelName, onTab
       </div>
 
       <div className="shrink-0 px-3.5 py-3.5 border-t border-stroke/80 bg-elevated/20 space-y-3">
+        <SidebarUpdateBanner />
         {settings && (
           <div className="flex items-center justify-between gap-2 rounded-xl bg-surface border border-stroke px-3 py-2">
             <span className="text-[10px] font-medium tracking-widest uppercase text-muted">Hold</span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -67,42 +67,90 @@ export function Sidebar({ activeTab, appState, settings, currentModelName, onTab
             </div>
           </div>
 
-          {currentModelName && settings && (
+          {settings && (
             <div className="mt-4 px-1">
               {settings.engine_mode === "local" ? (
-                <div className="group flex items-center gap-1 px-1 py-1 h-9 rounded-xl bg-elevated border border-stroke hover:border-accent/20 transition-colors">
+                currentModelName ? (
+                  <div className="group flex items-center gap-1 px-1 py-1 h-9 rounded-xl bg-elevated border border-stroke hover:border-accent/20 transition-colors">
+                    <button
+                      onClick={onOpenEngineTab}
+                      className="flex items-center gap-2 flex-1 min-w-0 px-1.5 py-1 text-left transition-colors"
+                      aria-label={`Open engine, current model ${currentModelName}`}
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0 animate-pulse" />
+                      <span className="text-[11px] font-medium text-ink truncate flex-1" title={currentModelName}>
+                        {currentModelName}
+                      </span>
+                      <IconChevronRight className="w-3 h-3 shrink-0 text-muted/40 group-hover:text-muted" />
+                    </button>
+                    <button
+                      onClick={onUnloadModel}
+                      className="shrink-0 w-5 h-5 grid place-items-center rounded-full bg-surface border border-stroke text-muted hover:text-recording hover:border-recording/30 opacity-0 group-hover:opacity-100 focus:opacity-100 group-focus-within:opacity-100 transition-all transition-transform duration-150 active:scale-[0.98]"
+                      title="Unload model"
+                      aria-label="Unload model"
+                    >
+                      <IconCloseSmall className="w-3 h-3" />
+                    </button>
+                  </div>
+                ) : (
                   <button
                     onClick={onOpenEngineTab}
-                    className="flex items-center gap-2 flex-1 min-w-0 px-1.5 py-1 text-left transition-colors"
-                    aria-label={`Open engine, current model ${currentModelName}`}
+                    className="flex items-center gap-2 px-2.5 py-2 h-9 rounded-xl bg-elevated border border-amber-500/20 hover:border-amber-500/30 w-full text-left transition-colors group"
                   >
-                    <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0 animate-pulse" />
-                    <span className="text-[11px] font-medium text-ink truncate flex-1" title={currentModelName}>
-                      {currentModelName}
-                    </span>
+                    <span className="w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" />
+                    <span className="text-[11px] font-medium text-amber-600 truncate flex-1">No local model</span>
                     <IconChevronRight className="w-3 h-3 shrink-0 text-muted/40 group-hover:text-muted" />
                   </button>
+                )
+              ) : (() => {
+                const hasCloudCfg = (() => {
+                  const keyOk = (() => {
+                    switch (settings.engine_provider) {
+                      case "openai":
+                        return settings.voice_api_key_openai.trim() !== "" || settings.voice_api_key.trim() !== "";
+                      case "groq":
+                        return settings.voice_api_key_groq.trim() !== "" || settings.voice_api_key.trim() !== "";
+                      case "custom":
+                        return settings.voice_api_key_custom.trim() !== "" || settings.voice_api_key.trim() !== "";
+                      default:
+                        return settings.voice_api_key.trim() !== "";
+                    }
+                  })();
+                  const baseOk = settings.engine_provider !== "custom" || settings.engine_base_url.trim() !== "";
+                  return keyOk && settings.engine_model.trim() !== "" && baseOk;
+                })();
+                if (hasCloudCfg) {
+                  const providerLabel =
+                    settings.engine_provider === "openai"
+                      ? "OpenAI"
+                      : settings.engine_provider === "groq"
+                      ? "Groq"
+                      : "Custom";
+                  const cloudName = `${providerLabel} · ${settings.engine_model}`;
+                  return (
+                    <button
+                      onClick={onOpenEngineTab}
+                      className="transition-transform duration-150 active:scale-[0.98] flex items-center gap-2 px-2.5 py-2 h-9 rounded-xl bg-elevated border border-stroke hover:border-accent/20 w-full text-left transition-colors group"
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full bg-ready shrink-0" />
+                      <span className="text-[11px] font-medium text-ink truncate flex-1" title={cloudName}>
+                        {cloudName}
+                      </span>
+                      <IconChevronRight className="w-3 h-3 shrink-0 text-muted/40 group-hover:text-muted" />
+                    </button>
+                  );
+                }
+                return (
                   <button
-                    onClick={onUnloadModel}
-                    className="shrink-0 w-5 h-5 grid place-items-center rounded-full bg-surface border border-stroke text-muted hover:text-recording hover:border-recording/30 opacity-0 group-hover:opacity-100 focus:opacity-100 group-focus-within:opacity-100 transition-all transition-transform duration-150 active:scale-[0.98]"
-                    title="Unload model"
-                    aria-label="Unload model"
+                    onClick={onOpenEngineTab}
+                    className="flex items-center gap-2 px-2.5 py-2 h-9 rounded-xl bg-elevated border border-amber-500/20 hover:border-amber-500/30 w-full text-left transition-colors group"
                   >
-                    <IconCloseSmall className="w-3 h-3" />
+                    <span className="w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0 animate-pulse" />
+                    <span className="text-[11px] font-medium text-amber-600 truncate flex-1">Cloud not configured</span>
+                    <IconChevronRight className="w-3 h-3 shrink-0 text-muted/40 group-hover:text-muted" />
                   </button>
-                </div>
-              ) : (
-                <button
-                  onClick={onOpenEngineTab}
-                  className="transition-transform duration-150 active:scale-[0.98] flex items-center gap-2 px-2.5 py-2 h-9 rounded-xl bg-elevated border border-stroke hover:border-accent/20 w-full text-left transition-colors group"
-                >
-                  <span className="w-1.5 h-1.5 rounded-full bg-ready shrink-0" />
-                  <span className="text-[11px] font-medium text-ink truncate flex-1" title={currentModelName}>
-                    {currentModelName}
-                  </span>
-                  <IconChevronRight className="w-3 h-3 shrink-0 text-muted/40 group-hover:text-muted" />
-                </button>
-              )}
+                );
+              })()}
             </div>
           )}
         </div>

--- a/src/components/SidebarUpdateBanner.tsx
+++ b/src/components/SidebarUpdateBanner.tsx
@@ -13,20 +13,6 @@ export function SidebarUpdateBanner() {
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
-    // Demo: ?demoUpdate=1 or dev build shows banner without a real release
-    try {
-      if (new URLSearchParams(window.location.search).has("demoUpdate")) {
-        setAvailable(true);
-        setVersion("3.3.0");
-        return;
-      }
-      // In dev, show a preview banner so you can see it in Wisper Dev window
-      if (import.meta.env.DEV) {
-        setAvailable(true);
-        setVersion("3.3.0");
-        return;
-      }
-    } catch {}
     if (dismissed) return;
     let mounted = true;
     async function poll() {

--- a/src/components/SidebarUpdateBanner.tsx
+++ b/src/components/SidebarUpdateBanner.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect, useCallback } from "react";
+import { check } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+type Phase = "idle" | "checking" | "downloading" | "done";
+
+export function SidebarUpdateBanner() {
+  const [available, setAvailable] = useState(false);
+  const [version, setVersion] = useState("");
+  const [dismissed, setDismissed] = useState(false);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [progress, setProgress] = useState(0);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    if (dismissed) return;
+    let mounted = true;
+    async function poll() {
+      try {
+        const update = await check();
+        if (!mounted) return;
+        if (update?.available) {
+          setAvailable(true);
+          setVersion(update.version);
+        }
+      } catch {}
+    }
+    poll();
+    const id = setInterval(poll, 3_600_000);
+    return () => {
+      mounted = false;
+      clearInterval(id);
+    };
+  }, [dismissed]);
+
+  const handleUpdate = useCallback(async () => {
+    setPhase("checking");
+    try {
+      const update = await check();
+      if (!update?.available) {
+        setPhase("idle");
+        return;
+      }
+      setPhase("downloading");
+      await update.downloadAndInstall((event) => {
+        if (event.event === "Started") {
+          setProgress(0);
+          setTotal(event.data.contentLength ?? 0);
+        } else if (event.event === "Progress") {
+          setProgress((p) => p + event.data.chunkLength);
+        }
+      });
+      setPhase("done");
+    } catch {
+      setPhase("idle");
+    }
+  }, []);
+
+  const handleRestart = useCallback(async () => {
+    try {
+      await relaunch();
+    } catch {}
+  }, []);
+
+  if (!available || dismissed) return null;
+
+  const pct = total > 0 ? Math.min(100, (progress / total) * 100) : 0;
+  const isWorking = phase === "checking" || phase === "downloading";
+
+  return (
+    <div className="mx-1 rounded-xl bg-ready/10 ring-1 ring-ready/20 overflow-hidden">
+      <div className="px-3 py-2.5 flex items-start gap-2.5">
+        <span className="shrink-0 w-6 h-6 grid place-items-center rounded-lg bg-ready text-white mt-0.5">
+          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 16v-8" />
+            <path d="M8 12l4 4 4-4" />
+            <path d="M20 16v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2" />
+          </svg>
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-[11px] font-medium text-ink leading-none">
+            {phase === "done" ? "Update ready" : `v${version} available`}
+          </p>
+          <p className="text-[10px] font-mono text-muted leading-tight mt-1">
+            {phase === "done" ? "Restart to apply" : phase === "downloading" ? "Downloading…" : "New version ready to install"}
+          </p>
+          <div className="flex items-center gap-2 mt-2">
+            {phase === "done" ? (
+              <button
+                onClick={handleRestart}
+                className="text-[11px] font-medium text-ready hover:text-ready/80 transition-colors"
+              >
+                Restart now →
+              </button>
+            ) : (
+              <button
+                onClick={handleUpdate}
+                disabled={isWorking}
+                className="text-[11px] font-medium text-ready hover:text-ready/80 disabled:opacity-40 transition-colors"
+              >
+                {phase === "checking" ? "Checking…" : phase === "downloading" ? "Downloading…" : "Update now"}
+              </button>
+            )}
+            <button
+              onClick={() => setDismissed(true)}
+              className="text-[10px] font-mono text-muted hover:text-ink transition-colors ml-auto"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      </div>
+      {phase === "downloading" && total > 0 && (
+        <div className="h-1 bg-ready/20">
+          <div className="h-full bg-ready transition-all duration-300" style={{ width: `${pct}%` }} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SidebarUpdateBanner.tsx
+++ b/src/components/SidebarUpdateBanner.tsx
@@ -13,6 +13,20 @@ export function SidebarUpdateBanner() {
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
+    // Demo: ?demoUpdate=1 or dev build shows banner without a real release
+    try {
+      if (new URLSearchParams(window.location.search).has("demoUpdate")) {
+        setAvailable(true);
+        setVersion("3.3.0");
+        return;
+      }
+      // In dev, show a preview banner so you can see it in Wisper Dev window
+      if (import.meta.env.DEV) {
+        setAvailable(true);
+        setVersion("3.3.0");
+        return;
+      }
+    } catch {}
     if (dismissed) return;
     let mounted = true;
     async function poll() {
@@ -68,51 +82,45 @@ export function SidebarUpdateBanner() {
   const isWorking = phase === "checking" || phase === "downloading";
 
   return (
-    <div className="mx-1 rounded-xl bg-ready/10 ring-1 ring-ready/20 overflow-hidden">
-      <div className="px-3 py-2.5 flex items-start gap-2.5">
-        <span className="shrink-0 w-6 h-6 grid place-items-center rounded-lg bg-ready text-white mt-0.5">
+    <div className="mx-2 rounded-lg bg-elevated border border-stroke overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse shrink-0" />
+        <span className="text-[11px] font-mono font-medium text-ink tabular-nums">v{version}</span>
+        {phase !== "idle" && phase !== "done" && (
+          <span className="text-[10px] font-mono text-muted">
+            {phase === "downloading" ? "downloading" : "checking…"}
+          </span>
+        )}
+        <span className="flex-1" />
+        {phase === "done" ? (
+          <button
+            onClick={handleRestart}
+            className="text-[11px] font-medium text-accent hover:text-accent/80 transition-colors"
+          >
+            Restart
+          </button>
+        ) : (
+          <button
+            onClick={handleUpdate}
+            disabled={isWorking}
+            className="text-[11px] font-medium text-accent hover:text-accent/80 disabled:opacity-40 transition-colors"
+          >
+            {phase === "downloading" ? `${Math.round(pct)}%` : "Update"}
+          </button>
+        )}
+        <button
+          onClick={() => setDismissed(true)}
+          className="w-6 h-6 -mr-1 grid place-items-center rounded-md text-muted/50 hover:text-muted hover:bg-surface transition-colors shrink-0"
+          aria-label="Dismiss update"
+        >
           <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M12 16v-8" />
-            <path d="M8 12l4 4 4-4" />
-            <path d="M20 16v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2" />
+            <path d="M18 6L6 18M6 6l12 12" />
           </svg>
-        </span>
-        <div className="flex-1 min-w-0">
-          <p className="text-[11px] font-medium text-ink leading-none">
-            {phase === "done" ? "Update ready" : `v${version} available`}
-          </p>
-          <p className="text-[10px] font-mono text-muted leading-tight mt-1">
-            {phase === "done" ? "Restart to apply" : phase === "downloading" ? "Downloading…" : "New version ready to install"}
-          </p>
-          <div className="flex items-center gap-2 mt-2">
-            {phase === "done" ? (
-              <button
-                onClick={handleRestart}
-                className="text-[11px] font-medium text-ready hover:text-ready/80 transition-colors"
-              >
-                Restart now →
-              </button>
-            ) : (
-              <button
-                onClick={handleUpdate}
-                disabled={isWorking}
-                className="text-[11px] font-medium text-ready hover:text-ready/80 disabled:opacity-40 transition-colors"
-              >
-                {phase === "checking" ? "Checking…" : phase === "downloading" ? "Downloading…" : "Update now"}
-              </button>
-            )}
-            <button
-              onClick={() => setDismissed(true)}
-              className="text-[10px] font-mono text-muted hover:text-ink transition-colors ml-auto"
-            >
-              Dismiss
-            </button>
-          </div>
-        </div>
+        </button>
       </div>
       {phase === "downloading" && total > 0 && (
-        <div className="h-1 bg-ready/20">
-          <div className="h-full bg-ready transition-all duration-300" style={{ width: `${pct}%` }} />
+        <div className="h-0.5 bg-stroke">
+          <div className="h-full bg-accent transition-all duration-300" style={{ width: `${pct}%` }} />
         </div>
       )}
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,7 @@ export interface AppSettings {
   hotkey_mode: string;
   paste_method: string;
   paste_tool: string;
+  paste_add_trailing_space: boolean;
   vad_enabled: boolean;
   vad_threshold: number;
   noise_suppression_enabled: boolean;

--- a/src/utils/timeSaved.ts
+++ b/src/utils/timeSaved.ts
@@ -1,0 +1,16 @@
+/**
+ * Time saved vs typing — single source of truth.
+ * Mirrors `src-tauri/src/coordinator.rs:701-703` and `settings.rs:527`.
+ * 60 WPM = 1 word per second.
+ */
+export function calcSavedSeconds(words: number, durationMs: number): number {
+  const typing = words / 1.0;
+  const speak = durationMs / 1000;
+  return Math.max(0, Math.floor(typing - speak));
+}
+
+export function formatSaved(seconds: number): string {
+  if (seconds >= 3600) return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+  if (seconds >= 60) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  return `${seconds}s`;
+}


### PR DESCRIPTION
Moves update banner to sidebar (single, minimal, dev preview removed), adds collapsible Today stats (local midnight, reusable timeSaved util), de-duplicates tray to single Open Wisper, makes cloud config provider-aware (per-provider API key + base URL, shows correct model in sidebar/tray), adds Copy last transcription to tray (text-only) with history copy animation (scale + Copied! pulse), and adds trailing space after paste (General > Output toggle, default on). Includes chore(release): bump version to 3.2.0.