### PR TITLE
fix(updater): use latest.json and add manual update check

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,7 @@
     "applicationCategory": "UtilitiesApplication",
     "applicationSubCategory": "Voice dictation",
     "description": "Privacy-first voice dictation for Linux. Local ONNX transcription (Parakeet, Moonshine, IndicConformer), optional AI cleanup, types at your cursor. Works on Wayland and X11.",
-    "softwareVersion": "3.1.0",
+    "softwareVersion": "3.2.1",
     "url": "https://taraksh01.github.io/wisper/",
     "downloadUrl": "https://github.com/taraksh01/wisper/releases/latest",
     "license": "https://opensource.org/licenses/MIT",
@@ -112,7 +112,7 @@
     <!-- Hero: a Linux terminal, a Wisper session in progress, the pill on the line being dictated. -->
     <section class="hero">
       <div class="hero-head">
-        <p class="hero-tag mono">Wisper 3.1.0 &middot; Linux &middot; MIT</p>
+        <p class="hero-tag mono">Wisper 3.2.1 &middot; Linux &middot; MIT</p>
         <h1 class="hero-title">Dictation, at your cursor.</h1>
         <p class="hero-sub">
           Hold a key, talk, and your words type where you were going to type them anyway.
@@ -229,11 +229,11 @@
         </li>
         <li class="cell span-6">
           <h3>Your words, your way</h3>
-          <p>Custom vocabulary turns shortcuts into proper terms. Say "gpt", get "GPT". Scan past dictations to find new words worth saving.</p>
+          <p>Custom vocabulary turns shortcuts into proper terms. Say "gpt", get "GPT". 4 dictionary profiles (developer, email, messaging, general) with import/export and per-profile toggle. Scan past dictations to find new words worth saving.</p>
         </li>
         <li class="cell span-4">
           <h3>Look back</h3>
-          <p>Searchable history: replay the recording, re-transcribe, edit, copy. Set retention limits. See typing time saved.</p>
+          <p>Searchable history: replay the recording, re-transcribe, edit, copy. Collapsible Today shows today dictations/words/time saved. Set retention limits.</p>
         </li>
         <li class="cell span-4">
           <h3>Local or cloud</h3>
@@ -241,11 +241,11 @@
         </li>
         <li class="cell span-4">
           <h3>Out of the way</h3>
-          <p>Lives in the system tray. Close the window and it keeps running, ready for the next hotkey.</p>
+          <p>Lives in the system tray - Copy last transcription without opening the window. Close the window and it keeps running.</p>
         </li>
         <li class="cell span-6">
           <h3>Updates itself</h3>
-          <p>Checks GitHub releases and installs new versions in-app, with signed auto-updates. No hunting for downloads.</p>
+          <p>Checks GitHub releases and installs in-app (About → Check for updates, also sidebar banner), with signed auto-updates. No manual download.</p>
         </li>
         <li class="cell span-6">
           <h3>Starts with you</h3>
@@ -275,7 +275,7 @@
       <header class="section-head">
         <p class="eyebrow mono"># download</p>
         <h2 class="section-title">Download for Linux</h2>
-        <p class="section-lead">Wisper <span class="mono" id="version">v3.1.0</span>. The site fetches the latest release when it loads. Auto-update is built in.</p>
+        <p class="section-lead">Wisper <span class="mono" id="version">v3.2.1</span>. The site fetches the latest release when it loads. Auto-update is built in.</p>
       </header>
       <div class="download-grid" id="download-grid" data-repo="taraksh01/wisper">
         <p class="download-loading">Loading the latest release…</p>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@ Wisper is free and open source (MIT), built by Tarak Shaw. Optional AI cleanup c
 - Input: global hotkey, types at the cursor via the active window
 - License: MIT
 - Price: free
-- Optional: AI cleanup (opt-in), custom vocabulary, searchable dictation history, sound feedback
+- Optional: AI cleanup (opt-in), custom vocabulary + dictionary profiles, searchable history with Today stats, trailing space, sound feedback
 
 ## Links
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wisper",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Turn your voice into text right on your device, with your privacy always in your hands.",
   "author": "Tarak Shaw <taraksh01@gmail.com>",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "wisper"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "arboard",
  "cpal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wisper"
-version = "3.2.0"
+version = "3.2.1"
 description = "Turn your voice into text right on your device, with your privacy always in your hands."
 authors = ["Tarak Shaw <taraksh01@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFBRkZGMTE3OUVDNkI5NDIKUldSQ3VjYWVGL0gvR2hnUUhSVitNZHRGZFloUE1FeXRIdWpyZlNOcms4a3U0ZmJNcndUMFhwK20K",
       "endpoints": [
-        "https://github.com/taraksh01/wisper/releases/latest/download/updater.json"
+        "https://github.com/taraksh01/wisper/releases/latest/download/latest.json"
       ]
     }
   }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Wisper",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "identifier": "com.taraksh01.wisper",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AboutTab.tsx
+++ b/src/components/AboutTab.tsx
@@ -38,10 +38,42 @@ const STEPS: Step[] = [
 export function AboutTab() {
   const [version, setVersion] = useState("");
   const [stars, setStars] = useState<number | null>(null);
+  const [updateStatus, setUpdateStatus] = useState<"idle" | "checking" | "available" | "upToDate" | "error">("idle");
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
 
   useEffect(() => {
     getVersion().then(setVersion).catch(() => {});
   }, []);
+
+  const checkForUpdates = async () => {
+    setUpdateStatus("checking");
+    try {
+      const { check } = await import("@tauri-apps/plugin-updater");
+      const update = await check();
+      if (update?.available) {
+        setLatestVersion(update.version);
+        setUpdateStatus("available");
+      } else {
+        setUpdateStatus("upToDate");
+        setTimeout(() => setUpdateStatus("idle"), 3000);
+      }
+    } catch {
+      setUpdateStatus("error");
+      setTimeout(() => setUpdateStatus("idle"), 3000);
+    }
+  };
+
+  const handleUpdate = async () => {
+    try {
+      const { check } = await import("@tauri-apps/plugin-updater");
+      const { relaunch } = await import("@tauri-apps/plugin-process");
+      const update = await check();
+      if (update?.available) {
+        await update.downloadAndInstall();
+        await relaunch();
+      }
+    } catch {}
+  };
 
   useEffect(() => {
     const ac = new AbortController();
@@ -103,6 +135,32 @@ export function AboutTab() {
             <span className="text-ink font-medium">on your own machine</span>, ready
             to paste into whatever you're doing.
           </p>
+          <div className="flex items-center justify-center gap-2 mt-4">
+            <button
+              onClick={checkForUpdates}
+              disabled={updateStatus === "checking"}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono text-ink bg-elevated ring-1 ring-stroke hover:bg-elevated/80 rounded-lg transition-colors disabled:opacity-50 pressable"
+            >
+              {updateStatus === "checking" ? "Checking…" : "Check for updates"}
+            </button>
+            {updateStatus === "available" && latestVersion && (
+              <button
+                onClick={handleUpdate}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono text-white bg-accent hover:bg-accent-dim rounded-lg transition-colors pressable"
+              >
+                Update to v{latestVersion}
+              </button>
+            )}
+            {updateStatus === "upToDate" && (
+              <span className="text-xs font-mono text-ready">Up to date</span>
+            )}
+            {updateStatus === "error" && (
+              <span className="text-xs font-mono text-recording">Check failed</span>
+            )}
+          </div>
+          {updateStatus === "available" && (
+            <p className="text-[10px] font-mono text-muted mt-2">v{latestVersion} is available — updates install in-app, no manual download needed.</p>
+          )}
         </div>
       </SectionCard>
 

--- a/src/components/AboutTab.tsx
+++ b/src/components/AboutTab.tsx
@@ -135,33 +135,46 @@ export function AboutTab() {
             <span className="text-ink font-medium">on your own machine</span>, ready
             to paste into whatever you're doing.
           </p>
-          <div className="flex items-center justify-center gap-2 mt-4">
+        </div>
+      </SectionCard>
+
+      {/* ── Updates: in-app, no manual download ── */}
+      <SectionCard className="card-enter">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-xs font-medium text-ink">Updates</h3>
+            <p className="text-[11px] text-muted leading-relaxed">Check for new versions and install in-app.</p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
             <button
               onClick={checkForUpdates}
               disabled={updateStatus === "checking"}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono text-ink bg-elevated ring-1 ring-stroke hover:bg-elevated/80 rounded-lg transition-colors disabled:opacity-50 pressable"
+              className="px-3 py-1.5 text-xs font-mono font-medium text-ink bg-elevated ring-1 ring-stroke hover:bg-elevated/80 rounded-lg transition-colors disabled:opacity-50 pressable"
             >
               {updateStatus === "checking" ? "Checking…" : "Check for updates"}
             </button>
             {updateStatus === "available" && latestVersion && (
               <button
                 onClick={handleUpdate}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono text-white bg-accent hover:bg-accent-dim rounded-lg transition-colors pressable"
+                className="px-3 py-1.5 text-xs font-mono font-medium text-white bg-accent hover:bg-accent-dim rounded-lg transition-colors pressable"
               >
                 Update to v{latestVersion}
               </button>
             )}
-            {updateStatus === "upToDate" && (
-              <span className="text-xs font-mono text-ready">Up to date</span>
-            )}
-            {updateStatus === "error" && (
-              <span className="text-xs font-mono text-recording">Check failed</span>
-            )}
           </div>
-          {updateStatus === "available" && (
-            <p className="text-[10px] font-mono text-muted mt-2">v{latestVersion} is available — updates install in-app, no manual download needed.</p>
-          )}
         </div>
+        {updateStatus === "upToDate" && (
+          <p className="text-[11px] font-mono text-ready mt-2">You are up to date (v{version}).</p>
+        )}
+        {updateStatus === "error" && (
+          <p className="text-[11px] font-mono text-recording mt-2">Check failed — try again.</p>
+        )}
+        {updateStatus === "available" && (
+          <p className="text-[11px] font-mono text-muted mt-2">v{latestVersion} ready — installs in-app, no manual download.</p>
+        )}
+        {updateStatus === "idle" && (
+          <p className="text-[10px] font-mono text-muted/60 mt-2">Current: v{version} · Updates install directly from the app.</p>
+        )}
       </SectionCard>
 
       {/* ── How it works: horizontal pipeline ── */}


### PR DESCRIPTION
Fixes in-app updates (were 404 on updater.json) and adds explicit manual check.

**Updater**
- `tauri.conf.json`: `updater.json` → `latest.json` (tauri-action uploads `latest.json`, previous endpoint 404 blocked updates)

**About → Updates card**
- Move Check for updates out of hero into dedicated Updates SectionCard (no hero bump)
- States: idle (Current: vX), checking, available → Update to vX, upToDate, error
- Update to vX runs check() → downloadAndInstall() → relaunch() in-app, no manual download

**Version**
- Bump to 3.2.1 to avoid conflict with published 3.2.0 (package.json, Cargo.toml, tauri.conf.json)