### PR TITLE
feat(windows): Windows beta support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,6 @@ jobs:
           releaseName: Wisper v__VERSION__${{ startsWith(github.ref_name, 'win-v') && ' (Windows)' || '' }}
           releaseBody: "See the assets below for the packages (deb, rpm, AppImage on Linux; NSIS on Windows)."
           releaseDraft: true
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, 'beta') }}
           uploadUpdaterJson: true
           args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,15 @@ on:
   push:
     tags:
       - "v*"
+      - "win-v*"
   workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform to build (linux, windows, all)"
+        required: false
+        default: "all"
+        type: choice
+        options: ["all", "linux", "windows"]
 
 permissions:
   contents: write
@@ -16,16 +24,26 @@ jobs:
       matrix:
         include:
           - platform: ubuntu-24.04
+            os: linux
             args: ""
+          - platform: windows-latest
+            os: windows
+            args: ""
+        exclude: []
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Linux build deps
+        if: matrix.os == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libasound2-dev libayatana-appindicator3-dev patchelf rpm
+
+      - name: Skip non-matching platform (manual dispatch)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'all' && github.event.inputs.platform != matrix.os
+        run: echo "Skipping ${{ matrix.os }} (requested ${{ github.event.inputs.platform }})" && exit 78
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -58,8 +76,8 @@ jobs:
         with:
           projectPath: src-tauri
           tagName: v__VERSION__
-          releaseName: Wisper v__VERSION__
-          releaseBody: "See the assets below for the Linux packages (deb, rpm, AppImage)."
+          releaseName: Wisper v__VERSION__${{ startsWith(github.ref_name, 'win-v') && ' (Windows)' || '' }}
+          releaseBody: "See the assets below for the packages (deb, rpm, AppImage on Linux; NSIS on Windows)."
           releaseDraft: true
           prerelease: false
           uploadUpdaterJson: true

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default Wisper auto-detects the best available tool, but you can pick a speci
 - **Frontend:** React + TypeScript + Vite + Tailwind CSS
 - **Backend:** Tauri v2 (Rust)
 - **STT:** local ONNX models + optional cloud APIs (OpenAI-compatible)
-- **Platform:** Linux (X11 and Wayland), distributed as AppImage / deb / rpm
+- **Platform:** Linux (X11 and Wayland), distributed as AppImage / deb / rpm — Windows beta in progress (`feat/windows-beta`, same Rust logic with WASAPI/Enigo shims, `nsis` bundle)
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wisper",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.3.0-beta.1",
   "description": "Turn your voice into text right on your device, with your privacy always in your hands.",
   "author": "Tarak Shaw <taraksh01@gmail.com>",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "wisper"
-version = "3.2.1"
+version = "3.3.0-beta.1"
 dependencies = [
  "arboard",
  "cpal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wisper"
-version = "3.2.1"
+version = "3.3.0-beta.1"
 description = "Turn your voice into text right on your device, with your privacy always in your hands."
 authors = ["Tarak Shaw <taraksh01@gmail.com>"]
 edition = "2021"

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -19,6 +19,43 @@ pub fn was_capped_and_reset() -> bool {
 /// are skipped since they are not real microphones.
 /// Returns an empty vector if enumeration fails.
 pub fn list_input_devices() -> Vec<(String, String)> {
+    #[cfg(target_os = "windows")]
+    {
+        let host = cpal::default_host();
+        let Ok(devices) = host.input_devices() else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for d in devices {
+            let raw_name = d.to_string();
+            if raw_name.is_empty() {
+                continue;
+            }
+            let id = d
+                .id()
+                .ok()
+                .map(|i| i.to_string())
+                .unwrap_or(raw_name.clone());
+            let name = d
+                .description()
+                .ok()
+                .and_then(|dd| {
+                    dd.name()
+                        .to_string()
+                        .lines()
+                        .next()
+                        .map(|s| s.trim().to_string())
+                })
+                .filter(|s| !s.is_empty())
+                .unwrap_or(raw_name);
+            if name.is_empty() {
+                continue;
+            }
+            out.push((id, name));
+        }
+        out.sort_by(|a, b| a.1.to_ascii_lowercase().cmp(&b.1.to_ascii_lowercase()));
+        return out;
+    }
     let mut hosts = cpal::available_hosts();
     if hosts.is_empty() {
         hosts.push(cpal::default_host().id());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,14 @@ where
     f()
 }
 
+#[cfg(not(target_os = "linux"))]
+pub fn silence_stderr<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    f()
+}
+
 use tauri::{Emitter, Manager, WindowEvent};
 use tauri_plugin_autostart::ManagerExt;
 

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -59,8 +59,12 @@ fn is_executable(path: &std::path::Path) -> bool {
     path.is_file()
 }
 
-/// Detects the current display server session: "wayland", "x11", or "unknown".
+/// Detects the current display server session: "wayland", "x11", "windows", or "unknown".
 pub fn detect_session_type() -> String {
+    #[cfg(target_os = "windows")]
+    {
+        return "windows".into();
+    }
     if let Ok(t) = std::env::var("XDG_SESSION_TYPE") {
         let t = t.to_lowercase();
         if t == "wayland" || t == "x11" {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Wisper",
-  "version": "3.2.1",
+  "version": "3.3.0-beta.1",
   "identifier": "com.taraksh01.wisper",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,8 @@
     "targets": [
       "appimage",
       "deb",
-      "rpm"
+      "rpm",
+      "nsis"
     ],
     "publisher": "Tarak Shaw",
     "shortDescription": "Turn your voice into text right on your device, with your privacy always in your hands.",

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -32,10 +32,11 @@ function Keycap({ children, active }: { children: React.ReactNode; active?: bool
 }
 
 function HotkeyDisplay({ hotkey }: { hotkey: string }) {
+  const isWindows = typeof navigator !== "undefined" && navigator.userAgent.includes("Windows");
   const pretty: Record<string, string> = {
-    Super: "Meta",
-    SuperLeft: "Meta L",
-    SuperRight: "Meta R",
+    Super: isWindows ? "Win" : "Meta",
+    SuperLeft: isWindows ? "Win L" : "Meta L",
+    SuperRight: isWindows ? "Win R" : "Meta R",
     CtrlLeft: "Ctrl L",
     CtrlRight: "Ctrl R",
     AltLeft: "Alt L",


### PR DESCRIPTION
Windows beta support with same Rust logic, platform shims only.

Backend shims:
- paste.rs: detect_session_type returns windows on cfg(windows), enigo fallback for paste
- lib.rs: silence_stderr no-ops on not(linux) so handy-keys init works
- audio.rs: simplified WASAPI device enumeration via default_host only
- tauri.conf.json: add nsis target alongside appimage/deb/rpm

UI:
- GeneralTab: show Win instead of Meta for Super key on Windows
- README: note Windows beta in progress

CI:
- release.yml: add windows-latest matrix entry, gate Linux deps on os == linux
- Trigger on win-v* tags for Windows-only betas, workflow_dispatch platform linux/windows/all with skip (exit 78)

Local-only testing so far (cargo check clean). Windows installer to be built via CI on win-v tag.