### PR TITLE
Windows beta channel (3.3.0-beta.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 # Two separate jobs (not a matrix) so beta tags can skip Linux entirely:
 # a skipped job shows gray instead of failing the run. Job-level `if`
 # only uses github/event/inputs contexts - never matrix (unavailable
@@ -29,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Linux build deps
         run: |
@@ -39,10 +43,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "11"
+          version: "12"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
@@ -78,15 +82,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "11"
+          version: "12"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
@@ -119,7 +123,7 @@ jobs:
           # Beta builds point the in-app updater at the rolling beta feed
           # instead of /latest (which excludes prereleases). Stable builds
           # keep the default endpoint from tauri.conf.json.
-          args: ${{ contains(github.ref_name, 'beta') && format('--config {0}/src-tauri/tauri.beta.json', github.workspace) || '' }}
+          args: ${{ contains(github.ref_name, 'beta') && format('--config "{0}/src-tauri/tauri.beta.json"', github.workspace) || '' }}
 
   # Republishes this tag's latest.json to a floating `beta` release so
   # installed betas (which point at .../releases/download/beta/latest.json)
@@ -131,7 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Fetch this tag's latest.json
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Guard tag matches version
+        shell: bash
         run: |
           ver=$(python3 -c "import json; print(json.load(open('src-tauri/tauri.conf.json'))['version'])")
           pkg=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
@@ -115,6 +116,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Guard tag matches version
+        shell: bash
         run: |
           ver=$(python3 -c "import json; print(json.load(open('src-tauri/tauri.conf.json'))['version'])")
           pkg=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,14 @@ jobs:
       - name: Install frontend deps
         run: pnpm install --frozen-lockfile
 
+      - name: Guard tag matches version
+        run: |
+          ver=$(python3 -c "import json; print(json.load(open('src-tauri/tauri.conf.json'))['version'])")
+          pkg=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+          cargo=$(python3 -c "import re; print(re.search(r'^version\s*=\s*\"([^\"]+)\"', open('src-tauri/Cargo.toml').read(), re.M).group(1))")
+          [ "$ver" = "$pkg" ] && [ "$ver" = "$cargo" ] || { echo "version drift: tauri=$ver pkg=$pkg cargo=$cargo"; exit 1; }
+          if [ "${{ github.event_name }}" = "push" ]; then [ "v$ver" = "${{ github.ref_name }}" ] || { echo "tag ${{ github.ref_name }} != v$ver"; exit 1; }; fi
+
       - name: Build + release
         uses: tauri-apps/tauri-action@v1
         env:
@@ -105,6 +113,14 @@ jobs:
 
       - name: Install frontend deps
         run: pnpm install --frozen-lockfile
+
+      - name: Guard tag matches version
+        run: |
+          ver=$(python3 -c "import json; print(json.load(open('src-tauri/tauri.conf.json'))['version'])")
+          pkg=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+          cargo=$(python3 -c "import re; print(re.search(r'^version\s*=\s*\"([^\"]+)\"', open('src-tauri/Cargo.toml').read(), re.M).group(1))")
+          [ "$ver" = "$pkg" ] && [ "$ver" = "$cargo" ] || { echo "version drift: tauri=$ver pkg=$pkg cargo=$cargo"; exit 1; }
+          if [ "${{ github.event_name }}" = "push" ]; then [ "v$ver" = "${{ github.ref_name }}" ] || { echo "tag ${{ github.ref_name }} != v$ver"; exit 1; }; fi
 
       - name: Build + release
         uses: tauri-apps/tauri-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-      - "win-v*"
   workflow_dispatch:
     inputs:
       platform:
@@ -19,6 +18,9 @@ permissions:
 
 jobs:
   release:
+    # Beta tags (e.g. v3.3.0-beta.1) build Windows only; stable tags build all platforms.
+    # Plain v tags are the only supported trigger: tagName v__VERSION__ must match the pushed tag.
+    if: ${{ github.event_name != 'push' || !contains(github.ref_name, 'beta') || matrix.os == 'windows' }}
     strategy:
       fail-fast: false
       matrix:
@@ -76,8 +78,8 @@ jobs:
         with:
           projectPath: src-tauri
           tagName: v__VERSION__
-          releaseName: Wisper v__VERSION__${{ startsWith(github.ref_name, 'win-v') && ' (Windows)' || '' }}
-          releaseBody: "See the assets below for the packages (deb, rpm, AppImage on Linux; NSIS on Windows)."
+          releaseName: Wisper v__VERSION__${{ contains(github.ref_name, 'beta') && ' (Windows beta)' || '' }}
+          releaseBody: ${{ contains(github.ref_name, 'beta') && 'Windows beta - NSIS installer below. Not for production use yet.' || 'See the assets below for the Linux packages (deb, rpm, AppImage).' }}
           releaseDraft: true
           prerelease: ${{ contains(github.ref_name, 'beta') }}
           uploadUpdaterJson: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,34 @@ jobs:
           releaseDraft: true
           prerelease: ${{ contains(github.ref_name, 'beta') }}
           uploadUpdaterJson: true
+          # Beta builds point the in-app updater at the rolling beta feed
+          # instead of /latest (which excludes prereleases). Stable builds
+          # keep the default endpoint from tauri.conf.json.
+          args: ${{ contains(github.ref_name, 'beta') && format('--config {0}/src-tauri/tauri.beta.json', github.workspace) || '' }}
+
+  # Republishes this tag's latest.json to a floating `beta` release so
+  # installed betas (which point at .../releases/download/beta/latest.json)
+  # discover new betas in-app. Stable /latest never includes prereleases,
+  # so stable installs are unaffected.
+  beta-feed:
+    needs: release-windows
+    if: github.event_name == 'push' && contains(github.ref_name, 'beta')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch this tag's latest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rm -rf /tmp/betafeed && mkdir -p /tmp/betafeed
+          gh release download "${{ github.ref_name }}" --pattern "latest.json" --dir /tmp/betafeed
+
+      - name: Republish floating beta feed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete beta --yes || true
+          git push origin :refs/tags/beta || true
+          gh release create beta --prerelease --title "Beta channel" --notes "Rolling beta feed for Wisper beta installs. Use the latest versioned beta for full installers." /tmp/betafeed/latest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,12 @@ permissions:
 
 jobs:
   release:
-    # Beta tags (e.g. v3.3.0-beta.1) build Windows only; stable tags build all platforms.
-    # Plain v tags are the only supported trigger: tagName v__VERSION__ must match the pushed tag.
-    if: ${{ github.event_name != 'push' || !contains(github.ref_name, 'beta') || matrix.os == 'windows' }}
+    # NOTE: do NOT filter here with matrix context - jobs.<job_id>.if is
+    # evaluated before matrix expansion, so matrix.* is unavailable and the
+    # whole run fails at startup with 0 jobs. Platform filtering lives in the
+    # "Check if this platform should build" step below (step-level ifs fully
+    # support matrix). Plain v tags are the only supported trigger: tagName
+    # v__VERSION__ must match the pushed tag.
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +37,13 @@ jobs:
         exclude: []
     runs-on: ${{ matrix.platform }}
     steps:
+      # Beta tags (e.g. v3.3.0-beta.1) build Windows only; stable tags build
+      # all platforms. Exit 78 marks this job neutral so the Linux leg ends
+      # in seconds without running the build.
+      - name: Check if this platform should build
+        if: github.event_name == 'push' && contains(github.ref_name, 'beta') && matrix.os == 'linux'
+        run: echo "Beta tag detected - Windows-only release, skipping Linux." && exit 78
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,46 +16,69 @@ on:
 permissions:
   contents: write
 
-jobs:
-  release:
-    # NOTE: do NOT filter here with matrix context - jobs.<job_id>.if is
-    # evaluated before matrix expansion, so matrix.* is unavailable and the
-    # whole run fails at startup with 0 jobs. Platform filtering lives in the
-    # "Check if this platform should build" step below (step-level ifs fully
-    # support matrix). Plain v tags are the only supported trigger: tagName
-    # v__VERSION__ must match the pushed tag.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: ubuntu-24.04
-            os: linux
-            args: ""
-          - platform: windows-latest
-            os: windows
-            args: ""
-        exclude: []
-    runs-on: ${{ matrix.platform }}
-    steps:
-      # Beta tags (e.g. v3.3.0-beta.1) build Windows only; stable tags build
-      # all platforms. Exit 78 marks this job neutral so the Linux leg ends
-      # in seconds without running the build.
-      - name: Check if this platform should build
-        if: github.event_name == 'push' && contains(github.ref_name, 'beta') && matrix.os == 'linux'
-        run: echo "Beta tag detected - Windows-only release, skipping Linux." && exit 78
+# Two separate jobs (not a matrix) so beta tags can skip Linux entirely:
+# a skipped job shows gray instead of failing the run. Job-level `if`
+# only uses github/event/inputs contexts - never matrix (unavailable
+# there and fails the run at startup). Plain v tags are the only
+# supported trigger: tagName v__VERSION__ must match the pushed tag.
 
+jobs:
+  release-linux:
+    # Stable tags only. Beta tags (containing 'beta') are Windows-only.
+    if: ${{ (github.event_name == 'push' && !contains(github.ref_name, 'beta')) || (github.event_name == 'workflow_dispatch' && (github.event.inputs.platform == 'all' || github.event.inputs.platform == 'linux')) }}
+    runs-on: ubuntu-24.04
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Linux build deps
-        if: matrix.os == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libasound2-dev libayatana-appindicator3-dev patchelf rpm
 
-      - name: Skip non-matching platform (manual dispatch)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.platform != 'all' && github.event.inputs.platform != matrix.os
-        run: echo "Skipping ${{ matrix.os }} (requested ${{ github.event.inputs.platform }})" && exit 78
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "11"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build + release
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: src-tauri
+          tagName: v__VERSION__
+          releaseName: Wisper v__VERSION__
+          releaseBody: "See the assets below for the Linux packages (deb, rpm, AppImage)."
+          releaseDraft: true
+          prerelease: ${{ contains(github.ref_name, 'beta') }}
+          uploadUpdaterJson: true
+
+  release-windows:
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.platform == 'all' || github.event.inputs.platform == 'windows')) }}
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -89,8 +112,7 @@ jobs:
           projectPath: src-tauri
           tagName: v__VERSION__
           releaseName: Wisper v__VERSION__${{ contains(github.ref_name, 'beta') && ' (Windows beta)' || '' }}
-          releaseBody: ${{ contains(github.ref_name, 'beta') && 'Windows beta - NSIS installer below. Not for production use yet.' || 'See the assets below for the Linux packages (deb, rpm, AppImage).' }}
+          releaseBody: ${{ contains(github.ref_name, 'beta') && 'Windows beta - NSIS installer below. Not for production use yet.' || 'See the assets below for the Windows installer (NSIS).' }}
           releaseDraft: true
           prerelease: ${{ contains(github.ref_name, 'beta') }}
           uploadUpdaterJson: true
-          args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,4 +170,5 @@ jobs:
         run: |
           gh release delete beta --yes || true
           git push origin :refs/tags/beta || true
+          git tag -d beta || true
           gh release create beta --prerelease --title "Beta channel" --notes "Rolling beta feed for Wisper beta installs. Use the latest versioned beta for full installers." /tmp/betafeed/latest.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Tarak Shaw <taraksh01@gmail.com>",
   "engines": {
     "node": "24",
-    "pnpm": "11"
+    "pnpm": "12"
   },
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wisper",
   "private": true,
-  "version": "3.3.0-beta.1",
+  "version": "3.3.0-beta.2",
   "description": "Turn your voice into text right on your device, with your privacy always in your hands.",
   "author": "Tarak Shaw <taraksh01@gmail.com>",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wisper",
   "private": true,
-  "version": "3.3.0-beta.2",
+  "version": "3.3.0-beta.3",
   "description": "Turn your voice into text right on your device, with your privacy always in your hands.",
   "author": "Tarak Shaw <taraksh01@gmail.com>",
   "engines": {

--- a/public/overlay.js
+++ b/public/overlay.js
@@ -114,6 +114,7 @@
 
   if (tauri && tauri.core) {
     setInterval(function () {
+      if (document.hidden) return;
       var t = performance.now() - start;
       tauri.core.invoke("get_input_level")
         .then(function (l) { render(l, t); })

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7107,7 +7107,7 @@ dependencies = [
 
 [[package]]
 name = "wisper"
-version = "3.3.0-beta.2"
+version = "3.3.0-beta.3"
 dependencies = [
  "arboard",
  "cpal",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
  "objc2-foundation",
  "web-sys",
  "windows 0.61.3",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2385,7 +2385,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6671,19 +6671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7152,6 +7139,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "transcribe-rs",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7107,7 +7107,7 @@ dependencies = [
 
 [[package]]
 name = "wisper"
-version = "3.3.0-beta.1"
+version = "3.3.0-beta.2"
 dependencies = [
  "arboard",
  "cpal",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7139,6 +7139,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tokio",
  "transcribe-rs",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wisper"
-version = "3.3.0-beta.2"
+version = "3.3.0-beta.3"
 description = "Turn your voice into text right on your device, with your privacy always in your hands."
 authors = ["Tarak Shaw <taraksh01@gmail.com>"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,13 +48,9 @@ sherpa-onnx = "1.13.5"
 ort = "2.0.0-rc.12"
 ndarray = "0.17"
 
-# Windows only: pin windows-core to the 0.61 line. cpal 0.18 allows
-# windows-core <=0.62, so Cargo otherwise mixes windows 0.61.3 with
-# windows-core 0.62.2, whose `implement` macro output no longer satisfies
-# cpal's trait bounds (E0277/E0599 in cpal's WASAPI backend).
+# Pin windows-core: cpal 0.18 breaks against 0.62 (E0277/E0599).
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-core = "=0.61.2"
-# Minimal Win32 surface for taskbar-aware overlay placement
-# (GetMonitorInfoW/MONITORINFOEXW live in Win32_Graphics_Gdi).
+# Win32 surface for taskbar-aware overlay placement.
 windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Graphics_Gdi"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,3 +48,10 @@ sherpa-onnx = "1.13.5"
 ort = "2.0.0-rc.12"
 ndarray = "0.17"
 
+# Windows only: pin windows-core to the 0.61 line. cpal 0.18 allows
+# windows-core <=0.62, so Cargo otherwise mixes windows 0.61.3 with
+# windows-core 0.62.2, whose `implement` macro output no longer satisfies
+# cpal's trait bounds (E0277/E0599 in cpal's WASAPI backend).
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-core = "=0.61.2"
+

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,4 +54,7 @@ ndarray = "0.17"
 # cpal's trait bounds (E0277/E0599 in cpal's WASAPI backend).
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-core = "=0.61.2"
+# Minimal Win32 surface for taskbar-aware overlay placement
+# (GetMonitorInfoW/MONITORINFOEXW live in Win32_Graphics_Gdi).
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Graphics_Gdi"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wisper"
-version = "3.3.0-beta.1"
+version = "3.3.0-beta.2"
 description = "Turn your voice into text right on your device, with your privacy always in your hands."
 authors = ["Tarak Shaw <taraksh01@gmail.com>"]
 edition = "2021"

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -268,6 +268,14 @@ impl AudioRecorder {
             let mut sr = self.sample_rate.lock().unwrap_or_else(|e| e.into_inner());
             *sr = config.sample_rate();
         }
+        if cfg!(debug_assertions) {
+            eprintln!(
+                "[audio] input config: {}Hz {}ch {:?}",
+                config.sample_rate(),
+                config.channels(),
+                config.sample_format()
+            );
+        }
 
         // Clear the buffer before starting
         self.buffer

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -459,6 +459,9 @@ impl AudioRecorder {
         f32: FromSample<T>,
     {
         let channels = config.channels as usize;
+        if channels == 0 {
+            return Err("Audio device reports zero channels".into());
+        }
         let err_fn = |err: cpal::Error| {
             if matches!(err.kind(), cpal::ErrorKind::Xrun) {
                 return;

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -19,8 +19,8 @@ pub fn was_capped_and_reset() -> bool {
 /// are skipped since they are not real microphones.
 /// Returns an empty vector if enumeration fails.
 pub fn list_input_devices() -> Vec<(String, String)> {
-    #[cfg(target_os = "windows")]
-    {
+    // cfg!: #[cfg] return would orphan the code below on Windows.
+    if cfg!(target_os = "windows") {
         let host = cpal::default_host();
         let Ok(devices) = host.input_devices() else {
             return Vec::new();

--- a/src-tauri/src/coordinator.rs
+++ b/src-tauri/src/coordinator.rs
@@ -627,6 +627,7 @@ fn run_pipeline(samples: Vec<f32>, device_sr: u32, cancel: CancelToken, my_seq: 
                 {
                     let (lock, cvar) = &*SEQ_CV;
                     let mut guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                    let wait_start = std::time::Instant::now();
                     while SEQ_TURN.load(Ordering::Relaxed) != my_seq {
                         if cancelled() {
                             drop(guard);
@@ -635,9 +636,15 @@ fn run_pipeline(samples: Vec<f32>, device_sr: u32, cancel: CancelToken, my_seq: 
                             );
                             return;
                         }
+                        if wait_start.elapsed() > std::time::Duration::from_secs(30) {
+                            eprintln!(
+                                "[paste] seq {my_seq} turn wait timed out - pasting out of order"
+                            );
+                            break;
+                        }
                         let (g, _) = cvar
                             .wait_timeout(guard, std::time::Duration::from_millis(25))
-                            .unwrap();
+                            .unwrap_or_else(|e| e.into_inner());
                         guard = g;
                     }
                 }

--- a/src-tauri/src/coordinator.rs
+++ b/src-tauri/src/coordinator.rs
@@ -222,11 +222,6 @@ fn finish_pipeline(my_seq: u64, cancel: &CancelToken) {
                 if cur == my_seq {
                     break;
                 }
-                if cur < my_seq {
-                    SEQ_TURN.store(my_seq + 1, Ordering::Relaxed);
-                    cvar.notify_all();
-                    return;
-                }
             }
             guard = cvar.wait(guard).unwrap_or_else(|e| e.into_inner());
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -373,6 +373,9 @@ fn create_overlay_with(app: &tauri::AppHandle, url: &str) {
             .always_on_top(true)
             .skip_taskbar(true)
             .transparent(true)
+            // No DWM drop shadow: on Windows the shadow of a transparent
+            // window renders as a visible ghost sheet behind the pill.
+            .shadow(false)
             .focusable(false)
             .focused(false)
             .visible(false);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -514,7 +514,18 @@ fn update_overlay(app: &tauri::AppHandle, state: CoordinatorState) {
                 if crate::coordinator::active_job_count() > 0 {
                     let _ = win.eval("window.__mode && window.__mode('processing')");
                 } else {
-                    let _ = win.destroy();
+                    // Windows: creating a WebView2 window costs 1-3s, so keep
+                    // the hidden window alive instead of rebuilding it on
+                    // every hotkey press. Linux WebKit rebuilds are instant,
+                    // keep destroy there.
+                    #[cfg(target_os = "windows")]
+                    {
+                        let _ = win.hide();
+                    }
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        let _ = win.destroy();
+                    }
                 }
             }
             CoordinatorState::Recording | CoordinatorState::Processing => {
@@ -688,6 +699,20 @@ pub fn run() {
             }
             settings::sync_runtime(&saved_settings);
             crate::tray::refresh();
+            // Windows: pre-create the hidden overlay after startup settles so
+            // even the first hotkey press doesn't pay WebView2 window-creation
+            // cost (1-3s). Serialized on the main thread with update_overlay,
+            // and create_overlay_with no-ops if the window already exists.
+            #[cfg(target_os = "windows")]
+            {
+                let prewarm_handle = app_handle.clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(3));
+                    let _ = prewarm_handle.run_on_main_thread(move || {
+                        create_overlay(&prewarm_handle);
+                    });
+                });
+            }
             // Enforce history retention limit on startup
             if saved_settings.max_history_entries > 0 {
                 let mode = if saved_settings.keep_recordings

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -406,6 +406,34 @@ fn create_overlay_with(app: &tauri::AppHandle, url: &str) {
 static LAST_OVERLAY_POS: once_cell::sync::Lazy<std::sync::Mutex<Option<(f64, f64)>>> =
     once_cell::sync::Lazy::new(|| std::sync::Mutex::new(None));
 
+/// Windows work area (screen minus taskbar) for the monitor containing the
+/// cursor, in physical pixels: (left, top, right, bottom). Returns None if
+/// the Win32 query fails (caller falls back to the full display rect).
+#[cfg(target_os = "windows")]
+fn windows_work_area_for_cursor(app: &tauri::AppHandle) -> Option<(i32, i32, i32, i32)> {
+    use windows::Win32::Foundation::POINT;
+    use windows::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromPoint, MONITORINFO, MONITORINFOEXW, MONITOR_DEFAULTTONEAREST,
+    };
+    let pos = app.cursor_position().ok()?;
+    let pt = POINT {
+        x: pos.x as i32,
+        y: pos.y as i32,
+    };
+    let hmon = unsafe { MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST) };
+    if hmon.is_invalid() {
+        return None;
+    }
+    let mut info: MONITORINFOEXW = unsafe { std::mem::zeroed() };
+    info.monitorInfo.cbSize = std::mem::size_of::<MONITORINFOEXW>() as u32;
+    let ok = unsafe { GetMonitorInfoW(hmon, &mut info.monitorInfo as *mut MONITORINFO) };
+    if !ok.as_bool() {
+        return None;
+    }
+    let r = info.monitorInfo.rcWork;
+    Some((r.left, r.top, r.right, r.bottom))
+}
+
 /// Computes the overlay's (x, y) logical position for a window of the given
 /// size. When `prefer_cache` is true it reuses the last recording position (so
 /// an error/recreated window stays put); otherwise it tracks the live cursor
@@ -430,10 +458,31 @@ fn overlay_pos_for(
     }
     let monitor = monitor_with_cursor(app)?;
     let scale = monitor.scale_factor();
-    let mx = monitor.position().x as f64 / scale;
-    let my = monitor.position().y as f64 / scale;
-    let mw = monitor.size().width as f64 / scale;
-    let mh = monitor.size().height as f64 / scale;
+    // Windows: Tauri reports the FULL display rect including the taskbar,
+    // so bottom-anchored overlays slide underneath it. Prefer the work area
+    // (screen minus taskbar) from GetMonitorInfo when available.
+    #[cfg(target_os = "windows")]
+    let (mx, my, mw, mh) = match windows_work_area_for_cursor(app) {
+        Some((l, t, r, b)) => (
+            l as f64 / scale,
+            t as f64 / scale,
+            (r - l) as f64 / scale,
+            (b - t) as f64 / scale,
+        ),
+        None => (
+            monitor.position().x as f64 / scale,
+            monitor.position().y as f64 / scale,
+            monitor.size().width as f64 / scale,
+            monitor.size().height as f64 / scale,
+        ),
+    };
+    #[cfg(not(target_os = "windows"))]
+    let (mx, my, mw, mh) = (
+        monitor.position().x as f64 / scale,
+        monitor.position().y as f64 / scale,
+        monitor.size().width as f64 / scale,
+        monitor.size().height as f64 / scale,
+    );
     let x = mx + (mw - win_w) / 2.0;
     let y = if top {
         my + OVERLAY_TOP_OFFSET

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -212,7 +212,13 @@ fn cancel_recording() {
 fn get_current_state() -> String {
     let state = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     match *state {
-        CoordinatorState::Idle => "idle".into(),
+        CoordinatorState::Idle => {
+            if crate::coordinator::active_job_count() > 0 {
+                "processing".into()
+            } else {
+                "idle".into()
+            }
+        }
         CoordinatorState::Recording => "recording".into(),
         CoordinatorState::Processing => "processing".into(),
         CoordinatorState::Error => "error".into(),
@@ -573,6 +579,7 @@ fn update_overlay(app: &tauri::AppHandle, state: CoordinatorState) {
                     // Windows: WebView2 creation costs 1-3s, so hide instead of rebuild.
                     #[cfg(target_os = "windows")]
                     {
+                        let _ = win.eval("window.__mode && window.__mode('idle')");
                         let _ = win.hide();
                     }
                     #[cfg(not(target_os = "windows"))]
@@ -618,6 +625,7 @@ pub fn hide_overlay() {
     let hide_handle = handle.clone();
     let _ = handle.run_on_main_thread(move || {
         if let Some(win) = hide_handle.get_webview_window(OVERLAY_LABEL) {
+            let _ = win.eval("window.__mode && window.__mode('idle')");
             let _ = win.hide();
         }
     });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -770,8 +770,12 @@ pub fn run() {
                 let prewarm_handle = app_handle.clone();
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(3));
+                    // Move a separate clone into the closure (same pattern as
+                    // update_overlay): the method receiver borrows
+                    // prewarm_handle, so the closure must own its own copy.
+                    let inner = prewarm_handle.clone();
                     let _ = prewarm_handle.run_on_main_thread(move || {
-                        create_overlay(&prewarm_handle);
+                        create_overlay(&inner);
                     });
                 });
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,6 +162,19 @@ fn list_audio_devices() -> Vec<(String, String)> {
     crate::audio::list_input_devices()
 }
 
+/// Types a fixed pangram via the normal paste path so users can isolate
+/// injection problems (wrong chars/spaces) from transcription problems.
+/// Uses the currently configured paste method.
+#[tauri::command]
+fn test_paste() -> Result<(), String> {
+    let method = crate::coordinator::PASTE_METHOD
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    let method = if method.is_empty() { "auto".to_string() } else { method };
+    crate::paste::paste_text("The quick brown fox 123", &method)
+}
+
 #[tauri::command]
 fn hide_main_window(app: tauri::AppHandle) -> Result<(), String> {
     if let Some(win) = app.get_webview_window("main") {
@@ -954,6 +967,7 @@ pub fn run() {
             start_mic_preview,
             stop_mic_preview,
             list_audio_devices,
+            test_paste,
             hide_main_window,
             quit_app
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,9 +162,7 @@ fn list_audio_devices() -> Vec<(String, String)> {
     crate::audio::list_input_devices()
 }
 
-/// Types a fixed pangram via the normal paste path so users can isolate
-/// injection problems (wrong chars/spaces) from transcription problems.
-/// Uses the currently configured paste method.
+/// Types a fixed pangram through the configured paste path (paste self-test).
 #[tauri::command]
 fn test_paste() -> Result<(), String> {
     let method = crate::coordinator::PASTE_METHOD
@@ -386,8 +384,7 @@ fn create_overlay_with(app: &tauri::AppHandle, url: &str) {
             .always_on_top(true)
             .skip_taskbar(true)
             .transparent(true)
-            // No DWM drop shadow: on Windows the shadow of a transparent
-            // window renders as a visible ghost sheet behind the pill.
+            // No DWM shadow: renders as a ghost sheet on transparent windows.
             .shadow(false)
             .focusable(false)
             .focused(false)
@@ -419,9 +416,8 @@ fn create_overlay_with(app: &tauri::AppHandle, url: &str) {
 static LAST_OVERLAY_POS: once_cell::sync::Lazy<std::sync::Mutex<Option<(f64, f64)>>> =
     once_cell::sync::Lazy::new(|| std::sync::Mutex::new(None));
 
-/// Windows work area (screen minus taskbar) for the monitor containing the
-/// cursor, in physical pixels: (left, top, right, bottom). Returns None if
-/// the Win32 query fails (caller falls back to the full display rect).
+/// Work area (screen minus taskbar) for the cursor monitor, physical pixels.
+/// None if the Win32 query fails; caller falls back to the full rect.
 #[cfg(target_os = "windows")]
 fn windows_work_area_for_cursor(app: &tauri::AppHandle) -> Option<(i32, i32, i32, i32)> {
     use windows::Win32::Foundation::POINT;
@@ -471,9 +467,7 @@ fn overlay_pos_for(
     }
     let monitor = monitor_with_cursor(app)?;
     let scale = monitor.scale_factor();
-    // Windows: Tauri reports the FULL display rect including the taskbar,
-    // so bottom-anchored overlays slide underneath it. Prefer the work area
-    // (screen minus taskbar) from GetMonitorInfo when available.
+    // Windows: anchor to the work area so the pill clears the taskbar.
     #[cfg(target_os = "windows")]
     let (mx, my, mw, mh) = match windows_work_area_for_cursor(app) {
         Some((l, t, r, b)) => (
@@ -576,10 +570,7 @@ fn update_overlay(app: &tauri::AppHandle, state: CoordinatorState) {
                 if crate::coordinator::active_job_count() > 0 {
                     let _ = win.eval("window.__mode && window.__mode('processing')");
                 } else {
-                    // Windows: creating a WebView2 window costs 1-3s, so keep
-                    // the hidden window alive instead of rebuilding it on
-                    // every hotkey press. Linux WebKit rebuilds are instant,
-                    // keep destroy there.
+                    // Windows: WebView2 creation costs 1-3s, so hide instead of rebuild.
                     #[cfg(target_os = "windows")]
                     {
                         let _ = win.hide();
@@ -761,18 +752,13 @@ pub fn run() {
             }
             settings::sync_runtime(&saved_settings);
             crate::tray::refresh();
-            // Windows: pre-create the hidden overlay after startup settles so
-            // even the first hotkey press doesn't pay WebView2 window-creation
-            // cost (1-3s). Serialized on the main thread with update_overlay,
-            // and create_overlay_with no-ops if the window already exists.
+            // Windows: pre-create the hidden overlay so the first hotkey is instant too.
             #[cfg(target_os = "windows")]
             {
                 let prewarm_handle = app_handle.clone();
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(3));
-                    // Move a separate clone into the closure (same pattern as
-                    // update_overlay): the method receiver borrows
-                    // prewarm_handle, so the closure must own its own copy.
+                    // Separate clone: the receiver borrows prewarm_handle.
                     let inner = prewarm_handle.clone();
                     let _ = prewarm_handle.run_on_main_thread(move || {
                         create_overlay(&inner);

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -35,7 +35,8 @@ pub fn get_models_dir() -> PathBuf {
 
 fn is_model_complete(dir: &std::path::Path, name: &str) -> bool {
     if name.starts_with("parakeet-") {
-        return true;
+        return dir.join("model.onnx").exists()
+            && (dir.join("tokens.txt").exists() || dir.join("vocab.json").exists());
     }
     if dir.join("model.onnx").exists() || dir.join("encoder_model.onnx").exists() {
         return true;

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -276,9 +276,7 @@ fn paste_via_clipboard(text: &str, method: &str) -> Result<(), String> {
     if ready {
         thread::sleep(Duration::from_millis(30));
     } else {
-        // Clipboard never confirmed our text (another app raced the update,
-        // e.g. a clipboard manager). Sending Ctrl+V now would paste STALE
-        // content, so type directly instead.
+        // Clipboard never confirmed our text; Ctrl+V would paste stale content.
         eprintln!("[paste] clipboard poll timed out after 100ms - falling back to direct typing");
         return type_text_directly(text);
     }

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -286,18 +286,16 @@ fn paste_via_clipboard(text: &str, method: &str) -> Result<(), String> {
     let restore_text: Option<String> = original_text.clone();
     thread::spawn(move || {
         thread::sleep(Duration::from_millis(100));
-        // Only restore if no newer dictation has overwritten the clipboard
         if CLIPBOARD_GEN.load(std::sync::atomic::Ordering::Relaxed) != gen {
             return;
         }
+        let Some(orig) = restore_text else {
+            return;
+        };
         if let Ok(mut c) = Clipboard::new() {
             if let Ok(cur) = c.get_text() {
                 if cur == expected {
-                    if let Some(orig) = restore_text {
-                        let _ = c.set_text(orig);
-                    } else {
-                        let _ = c.set_text(String::new());
-                    }
+                    let _ = c.set_text(orig);
                 }
             }
         }

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -61,8 +61,8 @@ fn is_executable(path: &std::path::Path) -> bool {
 
 /// Detects the current display server session: "wayland", "x11", "windows", or "unknown".
 pub fn detect_session_type() -> String {
-    #[cfg(target_os = "windows")]
-    {
+    // cfg!: #[cfg] return would orphan the code below on Windows.
+    if cfg!(target_os = "windows") {
         return "windows".into();
     }
     if let Ok(t) = std::env::var("XDG_SESSION_TYPE") {

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -276,7 +276,11 @@ fn paste_via_clipboard(text: &str, method: &str) -> Result<(), String> {
     if ready {
         thread::sleep(Duration::from_millis(30));
     } else {
-        eprintln!("[paste] clipboard poll timed out after 100ms");
+        // Clipboard never confirmed our text (another app raced the update,
+        // e.g. a clipboard manager). Sending Ctrl+V now would paste STALE
+        // content, so type directly instead.
+        eprintln!("[paste] clipboard poll timed out after 100ms - falling back to direct typing");
+        return type_text_directly(text);
     }
 
     let paste_result = simulate_key_combo(method);

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -26,21 +26,29 @@ fn command_exists(tool: &str) -> bool {
             }
         }
     }
+    let path_search = || {
+        std::env::var_os("PATH").map_or(false, |paths| {
+            std::env::split_paths(&paths).any(|dir| {
+                let full = dir.join(tool);
+                full.is_file() && is_executable(&full)
+            })
+        })
+    };
+    // No `which` on stock Windows; search PATH directly.
+    if cfg!(target_os = "windows") {
+        let result = path_search();
+        if let Ok(mut cache) = CMD_CACHE.lock() {
+            cache.insert(tool.to_string(), (result, std::time::Instant::now()));
+        }
+        return result;
+    }
     let result = Command::new("which")
         .arg(tool)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
-        .unwrap_or_else(|_| {
-            // Fallback: try `command -v` via direct PATH search
-            std::env::var_os("PATH").map_or(false, |paths| {
-                std::env::split_paths(&paths).any(|dir| {
-                    let full = dir.join(tool);
-                    full.is_file() && is_executable(&full)
-                })
-            })
-        });
+        .unwrap_or_else(|_| path_search());
     if let Ok(mut cache) = CMD_CACHE.lock() {
         cache.insert(tool.to_string(), (result, std::time::Instant::now()));
     }
@@ -168,12 +176,13 @@ fn active_backend() -> String {
 }
 
 pub fn paste_text(text: &str, method: &str) -> Result<(), String> {
+    let backend = active_backend();
     if cfg!(debug_assertions) {
         eprintln!(
             "[paste] paste_text method={} len={} backend={}",
             method,
             text.len(),
-            active_backend()
+            backend
         );
     }
     if text.trim().is_empty() {
@@ -189,18 +198,12 @@ pub fn paste_text(text: &str, method: &str) -> Result<(), String> {
     match &r {
         Ok(_) => {
             if cfg!(debug_assertions) {
-                eprintln!(
-                    "[paste] success method={} backend={}",
-                    method,
-                    active_backend()
-                );
+                eprintln!("[paste] success method={} backend={}", method, backend);
             }
         }
         Err(e) => eprintln!(
             "[paste] failed method={} backend={} err={}",
-            method,
-            active_backend(),
-            e
+            method, backend, e
         ),
     }
     r

--- a/src-tauri/src/whisper_keys.rs
+++ b/src-tauri/src/whisper_keys.rs
@@ -154,15 +154,14 @@ fn do_unregister_all(
 
 /// Forward a press/release into the coordinator's hotkey channel.
 fn forward(pressed: bool) {
-    if let Ok(guard) = HOTKEY_SENDER.lock() {
-        if let Some(tx) = guard.as_ref() {
-            if let Ok(s) = tx.lock() {
-                let _ = s.send(if pressed {
-                    HotkeyEvent::Pressed
-                } else {
-                    HotkeyEvent::Released
-                });
-            }
+    let guard = HOTKEY_SENDER.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(tx) = guard.as_ref() {
+        if let Ok(s) = tx.lock() {
+            let _ = s.send(if pressed {
+                HotkeyEvent::Pressed
+            } else {
+                HotkeyEvent::Released
+            });
         }
     }
 }

--- a/src-tauri/tauri.beta.json
+++ b/src-tauri/tauri.beta.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/taraksh01/wisper/releases/download/beta/latest.json"
+      ]
+    }
+  }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Wisper",
-  "version": "3.3.0-beta.2",
+  "version": "3.3.0-beta.3",
   "identifier": "com.taraksh01.wisper",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Wisper",
-  "version": "3.3.0-beta.1",
+  "version": "3.3.0-beta.2",
   "identifier": "com.taraksh01.wisper",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "title": "Wisper",
         "width": 900,
         "height": 700,
-        "resizable": false
+        "resizable": false,
+        "maximizable": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,13 +222,12 @@ function AppShell() {
   const settingsRef = useRef<AppSettings | null>(null);
   useEffect(() => { settingsRef.current = settings; }, [settings]);
   const saveSetting = <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
-    if (!settingsRef.current) return;
+    const base = settingsRef.current;
+    if (!base) return;
+    const updated = { ...base, [key]: value } as AppSettings;
     const msg = settingToast(key, value);
     setSettings((prev) => (prev ? ({ ...prev, [key]: value } as AppSettings) : prev));
     const task = async () => {
-      const base = settingsRef.current;
-      if (!base) return;
-      const updated = { ...base, [key]: value } as AppSettings;
       try {
         const trimmed = await invoke<number>("save_settings", { settings: updated });
         if (key === "max_history_entries" || key === "history_retention_mode") {
@@ -256,12 +255,11 @@ function AppShell() {
   };
 
   const saveAllSettings = (updates: Partial<AppSettings>) => {
-    if (!settingsRef.current) return;
+    const base = settingsRef.current;
+    if (!base) return;
+    const merged = { ...base, ...updates } as AppSettings;
     setSettings((prev) => (prev ? ({ ...prev, ...updates } as AppSettings) : prev));
     const task = async () => {
-      const base = settingsRef.current;
-      if (!base) return;
-      const merged = { ...base, ...updates } as AppSettings;
       try {
         await invoke("save_settings", { settings: merged });
         toast.addToast("Settings saved", "success");

--- a/src/components/AboutTab.tsx
+++ b/src/components/AboutTab.tsx
@@ -1,6 +1,6 @@
 import { IconAbout, IconMic, IconRecord, IconBars, IconProcess, IconInsert, IconShield } from "./ui/icons";
 import type { ComponentType, SVGProps } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { SectionCard } from "./SectionCard";
 import { APP_NAME, storageKey } from "../appConfig";
@@ -38,18 +38,23 @@ const STEPS: Step[] = [
 export function AboutTab() {
   const [version, setVersion] = useState("");
   const [stars, setStars] = useState<number | null>(null);
-  const [updateStatus, setUpdateStatus] = useState<"idle" | "checking" | "available" | "upToDate" | "error">("idle");
+  const [updateStatus, setUpdateStatus] = useState<"idle" | "checking" | "available" | "installing" | "upToDate" | "error">("idle");
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const pendingUpdate = useRef<{ version: string; downloadAndInstall: () => Promise<void> } | null>(null);
 
   useEffect(() => {
     getVersion().then(setVersion).catch(() => {});
   }, []);
 
   const checkForUpdates = async () => {
+    if (updateStatus === "checking" || updateStatus === "installing") return;
     setUpdateStatus("checking");
+    setUpdateError(null);
     try {
       const { check } = await import("@tauri-apps/plugin-updater");
       const update = await check();
+      pendingUpdate.current = update ?? null;
       if (update?.available) {
         setLatestVersion(update.version);
         setUpdateStatus("available");
@@ -57,22 +62,28 @@ export function AboutTab() {
         setUpdateStatus("upToDate");
         setTimeout(() => setUpdateStatus("idle"), 3000);
       }
-    } catch {
+    } catch (e) {
+      console.error("Update check failed:", e);
+      setUpdateError(e instanceof Error ? e.message : "Check failed");
       setUpdateStatus("error");
       setTimeout(() => setUpdateStatus("idle"), 3000);
     }
   };
 
   const handleUpdate = async () => {
+    const update = pendingUpdate.current;
+    if (updateStatus !== "available" || !update) return;
+    setUpdateStatus("installing");
+    setUpdateError(null);
     try {
-      const { check } = await import("@tauri-apps/plugin-updater");
       const { relaunch } = await import("@tauri-apps/plugin-process");
-      const update = await check();
-      if (update?.available) {
-        await update.downloadAndInstall();
-        await relaunch();
-      }
-    } catch {}
+      await update.downloadAndInstall();
+      await relaunch();
+    } catch (e) {
+      console.error("Update install failed:", e);
+      setUpdateError(e instanceof Error ? e.message : "Install failed");
+      setUpdateStatus("available");
+    }
   };
 
   useEffect(() => {
@@ -148,10 +159,10 @@ export function AboutTab() {
           <div className="flex items-center gap-2 shrink-0">
             <button
               onClick={checkForUpdates}
-              disabled={updateStatus === "checking"}
+              disabled={updateStatus === "checking" || updateStatus === "installing"}
               className="px-3 py-1.5 text-xs font-mono font-medium text-ink bg-elevated ring-1 ring-stroke hover:bg-elevated/80 rounded-lg transition-colors disabled:opacity-50 pressable"
             >
-              {updateStatus === "checking" ? "Checking…" : "Check for updates"}
+              {updateStatus === "checking" ? "Checking…" : updateStatus === "installing" ? "Installing…" : "Check for updates"}
             </button>
             {updateStatus === "available" && latestVersion && (
               <button
@@ -167,10 +178,13 @@ export function AboutTab() {
           <p className="text-[11px] font-mono text-ready mt-2">You are up to date (v{version}).</p>
         )}
         {updateStatus === "error" && (
-          <p className="text-[11px] font-mono text-recording mt-2">Check failed — try again.</p>
+          <p className="text-[11px] font-mono text-recording mt-2">{updateError ?? "Check failed"} — try again.</p>
         )}
         {updateStatus === "available" && (
           <p className="text-[11px] font-mono text-muted mt-2">v{latestVersion} ready — installs in-app, no manual download.</p>
+        )}
+        {updateStatus === "available" && updateError && (
+          <p className="text-[11px] font-mono text-recording mt-2">Install failed: {updateError}</p>
         )}
         {updateStatus === "idle" && (
           <p className="text-[10px] font-mono text-muted/60 mt-2">Current: v{version} · Updates install directly from the app.</p>

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -557,8 +557,7 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
     return () => clearTimeout(timerRef.current);
   }, []);
 
-  // Paste-test countdown: gives the user 3s to focus a target field
-  // (clicking the button steals focus, so typing must be deferred).
+  // Countdown lets the user focus a target field before typing starts.
   useEffect(() => {
     if (pasteTestIn === null) return;
     if (pasteTestIn <= 0) {

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -509,6 +509,7 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
   const [pendingMax, setPendingMax] = useState(settings.max_history_entries);
   const [trimConfirm, setTrimConfirm] = useState<{ newLimit: number; excess: number } | null>(null);
   const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [pasteTestIn, setPasteTestIn] = useState<number | null>(null);
   const dragIdxRef = useRef<number | null>(null);
   const btnRef = useRef<HTMLButtonElement>(null);
   const pendingModsRef = useRef<Set<string>>(new Set());
@@ -555,6 +556,19 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
   useEffect(() => {
     return () => clearTimeout(timerRef.current);
   }, []);
+
+  // Paste-test countdown: gives the user 3s to focus a target field
+  // (clicking the button steals focus, so typing must be deferred).
+  useEffect(() => {
+    if (pasteTestIn === null) return;
+    if (pasteTestIn <= 0) {
+      setPasteTestIn(null);
+      invoke("test_paste").catch((e) => console.error("test_paste failed:", e));
+      return;
+    }
+    const t = setTimeout(() => setPasteTestIn((v) => (v === null ? null : v - 1)), 1000);
+    return () => clearTimeout(t);
+  }, [pasteTestIn]);
 
   const showMessage = useCallback((text: string, ok: boolean) => {
     setMessage({ text, ok });
@@ -875,6 +889,28 @@ export function GeneralTab({ settings, historyTotal = 0, onSave, onSaveAll, onRe
             onChange={(v) => onSave("paste_method", v)}
           />
           <PasteToolControl value={settings.paste_tool} onChange={(v) => onSave("paste_tool", v)} />
+          <div className="flex items-center justify-between gap-3 pt-3 border-t border-stroke">
+            <div>
+              <span className="text-xs text-muted">Test paste</span>
+              <p className="text-[10px] font-mono text-muted/60 leading-relaxed">
+                {pasteTestIn === null
+                  ? "Click, focus any text field, types “The quick brown fox 123”."
+                  : `Focus your target field — typing in ${pasteTestIn}…`}
+              </p>
+            </div>
+            <button
+              onClick={() => {
+                if (pasteTestIn !== null) {
+                  setPasteTestIn(null);
+                } else {
+                  setPasteTestIn(3);
+                }
+              }}
+              className="shrink-0 px-3 py-1.5 text-xs font-mono text-accent ring-1 ring-stroke hover:bg-elevated/50 rounded-md transition-colors cursor-pointer"
+            >
+              {pasteTestIn === null ? "Type test" : `Cancel (${pasteTestIn})`}
+            </button>
+          </div>
           <div className="flex items-center justify-between gap-3 pt-3 border-t border-stroke">
             <div>
               <span className="text-xs text-muted">Add space after paste</span>

--- a/src/components/GeneralTab.tsx
+++ b/src/components/GeneralTab.tsx
@@ -239,6 +239,7 @@ function SupportedKeysModal({ onClose }: { onClose: () => void }) {
 }
 
 function VadThresholdControl({ threshold, onChange, inputDevice, disabled }: { threshold: number; onChange: (v: number) => void; inputDevice: string; disabled?: boolean }) {
+  const isWindows = typeof navigator !== "undefined" && navigator.userAgent.includes("Windows");
   const [level, setLevel] = useState(0);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const historyRef = useRef<number[]>([]);
@@ -469,6 +470,11 @@ function VadThresholdControl({ threshold, onChange, inputDevice, disabled }: { t
           </span>
           <span className="text-[10px] font-mono text-muted/80 text-right">Speak — bars should hit green, not red</span>
         </div>
+        {isWindows && isTooQuiet && (
+          <p className="text-[10px] font-mono text-muted/80 leading-relaxed pt-1.5 border-t border-stroke/50">
+            Meter flat on Windows? Allow microphone access: Settings → Privacy &amp; security → Microphone → let desktop apps use it.
+          </p>
+        )}
       </div>
 
       {/* Noise cutoff slider */}

--- a/src/components/HistoryTab.tsx
+++ b/src/components/HistoryTab.tsx
@@ -74,6 +74,8 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
   const [retranscribingId, setRetranscribingId] = useState<number | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
+  const [showDeleteSelectedConfirm, setShowDeleteSelectedConfirm] = useState(false);
   const [query, setQuery] = useState("");
   const [todayOpen, setTodayOpen] = useState(() => {
     try {
@@ -162,10 +164,15 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
   const deleteSelected = useCallback(async () => {
     const ids = Array.from(selectedIds);
     const results = await Promise.allSettled(ids.map((id) => invoke("delete_history_entry", { id })));
-    const fulfilled = results.filter((r) => r.status === "fulfilled").length;
-    const rejected = results.filter((r) => r.status === "rejected").length;
+    const failed = new Set<number>();
+    let fulfilled = 0;
+    results.forEach((r, i) => {
+      if (r.status === "fulfilled") fulfilled++;
+      else failed.add(ids[i]);
+    });
+    const rejected = failed.size;
     if (rejected > 0) console.error("Delete selected partially failed:", results);
-    setSelectedIds(new Set());
+    setSelectedIds(failed);
     onRefresh();
     if (rejected === 0) addToast(`${fulfilled} entries deleted`, "success");
     else if (fulfilled === 0) addToast("Failed to delete entries", "error");
@@ -474,7 +481,7 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
               </button>
             )}
             <button
-              onClick={deleteSelected}
+              onClick={() => setShowDeleteSelectedConfirm(true)}
               className="ml-auto text-[11px] font-mono text-recording/70 hover:text-recording transition-colors"
             >
               Delete selected
@@ -521,7 +528,7 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
                 onStartEdit={startEdit}
                 onCancelEdit={cancelEdit}
                 onSaveEdit={saveEdit}
-                onDelete={deleteEntry}
+                onDelete={() => setPendingDeleteId(entry.id)}
                 onEditRawChange={setEditRaw}
                 onEditFormattedChange={setEditFormatted}
               />
@@ -554,6 +561,33 @@ export function HistoryTab({ history, stats, settings, historyTotal, loadingOlde
           onToggle={togglePlayPause}
           onSeek={seekTo}
           onClose={closePlayer}
+        />
+      )}
+
+      {pendingDeleteId !== null && (
+        <ConfirmModal
+          title="Delete this entry?"
+          message="This will permanently delete the dictation and its recording."
+          confirmLabel="Delete"
+          onConfirm={async () => {
+            const id = pendingDeleteId;
+            setPendingDeleteId(null);
+            await deleteEntry(id);
+          }}
+          onCancel={() => setPendingDeleteId(null)}
+        />
+      )}
+
+      {showDeleteSelectedConfirm && (
+        <ConfirmModal
+          title={`Delete ${selectedIds.size} entries?`}
+          message="This will permanently delete the selected dictations and their recordings."
+          confirmLabel="Delete"
+          onConfirm={async () => {
+            setShowDeleteSelectedConfirm(false);
+            await deleteSelected();
+          }}
+          onCancel={() => setShowDeleteSelectedConfirm(false)}
         />
       )}
 

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -60,7 +60,7 @@ export function Select({
       if (idx === -1) idx = 0;
     }
     activeIndexRef.current = Math.max(0, idx);
-  }, [value, visibleOptions]);
+  }, [value, query, options]);
 
   useEffect(() => {
     if (activeIndexRef.current >= visibleOptions.length) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,7 +106,7 @@ body {
   opacity: 0.35;
   mask-image: radial-gradient(ellipse 800px 600px at 50% 0%, black 40%, transparent 75%);
 }
-.light .app-canvas::before {
+.light.app-canvas::before {
   opacity: 0.5;
 }
 


### PR DESCRIPTION
Ships the Windows-only beta line tested on hardware in beta.3.

Highlights
- NSIS target, WASAPI mic enumeration, Windows taskbar-aware overlay (keep-alive + prewarm, no ghost shadow)
- Paste: clipboard-timeout fallback to direct typing, paste self-test, non-text clipboard preserved
- Mic: quiet-input diagnostics and Windows privacy hint
- Updater: rolling beta feed so betas update in-app; stable /latest untouched
- Audit fixes: pipeline ordering, history delete confirms, settings save race, parakeet completeness, Select nav, About updater rework, CI guards (tag/version match, bash shell, local beta tag cleanup), pnpm 12, Node 24 actions

Verification: cargo check 0 warnings, cargo test 9/9, tsc clean, pnpm build green, release run 34341956712 fully green, beta.3 installer confirmed smooth on Windows.

Tags v3.3.0-beta.1/2/3 already published from this branch; no tag changes in this PR.